### PR TITLE
Extend login session to 48 hours

### DIFF
--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -58,7 +58,7 @@ const expectedTeamId = env.SLACK_TEAM_ID ?? (isDemoMode ? "T_DEMO" : "");
 
 export const authOptions: NextAuthOptions = {
   secret: env.AUTH_SECRET || (isDemoMode ? "hanabi-log-local-demo-secret" : undefined),
-  session: { strategy: "jwt", maxAge: 60 * 60 * 12 },
+  session: { strategy: "jwt", maxAge: 60 * 60 * 48 },
   pages: { signIn: "/login", error: "/login" },
   providers: isDemoMode
     ? [


### PR DESCRIPTION
## Summary
- Extend NextAuth JWT session maxAge from 12 hours to 48 hours

## Checks
- npm run typecheck
- npx eslint src/server/auth.ts --max-warnings=0
- npm test -- --run src/lib/authorization.test.ts

Closes #20