### PR TITLE
Align loading arch with Hanabi logo

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -277,30 +277,26 @@ strong {
 
 .initial-loading__arch-cover,
 .initial-loading__arch-progress {
-  fill: none;
-  stroke-linecap: butt;
-  stroke-linejoin: round;
-  stroke-width: 7;
-  vector-effect: non-scaling-stroke;
+  fill: #fff;
 }
 
-.initial-loading__arch-cover { stroke: #fff; }
 .initial-loading__arch-progress {
+  fill: var(--navy);
+}
+
+.initial-loading__arch-reveal {
   animation: initial-loading-arch 1.1s ease-in-out infinite alternate;
-  stroke: var(--navy);
-  stroke-dasharray: 1;
-  stroke-dashoffset: 1;
 }
 
 @keyframes initial-loading-arch {
-  from { stroke-dashoffset: 1; }
-  to { stroke-dashoffset: 0; }
+  from { width: 0; }
+  to { width: 100%; }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .initial-loading__arch-progress {
+  .initial-loading__arch-reveal {
     animation: none;
-    stroke-dashoffset: 0;
+    width: 100%;
   }
 }
 

--- a/src/components/initial-loading-screen.tsx
+++ b/src/components/initial-loading-screen.tsx
@@ -34,9 +34,14 @@ export function InitialLoadingScreen() {
     <div aria-busy="true" aria-label="読み込んでいます" className="initial-loading" role="status">
       <div className="initial-loading__logo">
         <HanabiLogo className="initial-loading__image" />
-        <svg aria-hidden="true" className="initial-loading__arch" viewBox="0 0 100 75">
-          <path className="initial-loading__arch-cover" d="M 0 62 Q 50 -8 100 62" pathLength="1" />
-          <path className="initial-loading__arch-progress" d="M 0 62 Q 50 -8 100 62" pathLength="1" />
+        <svg aria-hidden="true" className="initial-loading__arch" viewBox="0 0 100 72.86" preserveAspectRatio="none">
+          <defs>
+            <clipPath id="initial-loading-arch-reveal">
+              <rect className="initial-loading__arch-reveal" height="72.86" width="0" x="0" y="0" />
+            </clipPath>
+          </defs>
+          <path className="initial-loading__arch-cover" d="M 0 51.94 A 50 51.94 0 0 1 100 51.94 A 50 48.07 0 0 0 0 51.94 Z" />
+          <path className="initial-loading__arch-progress" d="M 0 51.94 A 50 51.94 0 0 1 100 51.94 A 50 48.07 0 0 0 0 51.94 Z" clipPath="url(#initial-loading-arch-reveal)" />
         </svg>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Align the loading arch overlay with the existing Hanabi PNG logo
- Reveal the corrected arch shape from left to right

## Checks
- npm run lint
- npm run typecheck