### PR TITLE
Remove loading arch vertical offset

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -272,7 +272,6 @@ strong {
   overflow: visible;
   pointer-events: none;
   position: absolute;
-  transform: translateY(1px);
   width: 100%;
 }
 


### PR DESCRIPTION
ローディングアーチを1px下げる指定を撤回し、頂点で元ロゴが露出して段差になる問題を解消します。左右端を覆うSVGパスは維持します。