### PR TITLE
fix: prevent Slack ingestion poison queues

### DIFF
--- a/src/app/api/integrations/slack/events/route.ts
+++ b/src/app/api/integrations/slack/events/route.ts
@@ -22,7 +22,13 @@ export async function POST(request: Request): Promise<Response> {
       await sql`insert into slack_incoming_reports (channel_id, message_ts, user_id, body, event_ts)
         values (${message.channel}, ${message.ts}, ${message.user}, ${message.text}, ${message.eventTs})
         on conflict (channel_id, message_ts) do update set
-          body = excluded.body, event_ts = excluded.event_ts, processed_at = null
+          body = excluded.body,
+          event_ts = excluded.event_ts,
+          processed_at = null,
+          attempts = 0,
+          available_at = now(),
+          last_error = null,
+          dead_at = null
         where slack_incoming_reports.event_ts < excluded.event_ts
           and slack_incoming_reports.user_id = excluded.user_id`;
     }
@@ -30,7 +36,13 @@ export async function POST(request: Request): Promise<Response> {
       await sql`insert into slack_report_reactions (channel_id, message_ts, user_id, reaction, active, event_ts)
         values (${reaction.item.channel}, ${reaction.item.ts}, ${reaction.user}, ${reaction.reaction}, ${reaction.type === "reaction_added"}, ${reaction.event_ts})
         on conflict (channel_id, message_ts, user_id, reaction) do update set
-          active = excluded.active, event_ts = excluded.event_ts, processed_at = null
+          active = excluded.active,
+          event_ts = excluded.event_ts,
+          processed_at = null,
+          attempts = 0,
+          available_at = now(),
+          last_error = null,
+          dead_at = null
         where slack_report_reactions.event_ts < excluded.event_ts`;
     }
     after(async () => {

--- a/src/server/integrations/slack-incoming-store.ts
+++ b/src/server/integrations/slack-incoming-store.ts
@@ -4,18 +4,30 @@ import { getDatabase } from "@/server/db/client";
 import { env, isDemoMode } from "@/server/env";
 import { resolveReportTitle } from "@/lib/report-title";
 
+const MAX_INGESTION_ATTEMPTS = 5;
+
 export async function processIncomingSlackReports(): Promise<void> {
   if (isDemoMode || !env.SLACK_TEAM_ID || !env.SLACK_BOT_TOKEN) return;
   const sql = getDatabase();
   const client = new WebClient(env.SLACK_BOT_TOKEN, { retryConfig: { retries: 0 }, timeout: 5000 });
-  const pending = await sql`select * from slack_incoming_reports where processed_at is null order by created_at limit 20`;
+  const pending = await sql`select * from slack_incoming_reports
+    where processed_at is null and dead_at is null and available_at <= now()
+    order by available_at, created_at limit 20`;
   for (const candidate of pending) {
     try {
       const existing = await sql`select id from members where slack_team_id = ${env.SLACK_TEAM_ID} and slack_user_id = ${candidate.user_id}`;
       const profile = existing.length ? undefined : (await client.users.info({ user: candidate.user_id })).user;
-      if (!existing.length && (!profile || profile.is_bot || profile.deleted)) continue;
+      if (!existing.length && (!profile || profile.is_bot || profile.deleted)) {
+        await sql`update slack_incoming_reports set dead_at = now(), last_error = 'slack_user_unavailable'
+          where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts}
+            and processed_at is null and dead_at is null`;
+        continue;
+      }
       await sql.begin(async (tx) => {
-        const [message] = await tx`select * from slack_incoming_reports where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts} and processed_at is null for update skip locked`;
+        const [message] = await tx`select * from slack_incoming_reports
+          where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts}
+            and processed_at is null and dead_at is null and available_at <= now()
+          for update skip locked`;
         if (!message) return;
         const body = message.body.replaceAll("&lt;", "<").replaceAll("&gt;", ">").replaceAll("&amp;", "&");
         if (message.imported) {
@@ -31,7 +43,8 @@ export async function processIncomingSlackReports(): Promise<void> {
               await tx`update integration_bindings set notion_status = 'pending', notion_last_error = null where report_id = ${report.id}`;
             }
           }
-          await tx`update slack_incoming_reports set processed_at = now() where channel_id = ${message.channel_id} and message_ts = ${message.message_ts}`;
+          await tx`update slack_incoming_reports set processed_at = now(), last_error = null
+            where channel_id = ${message.channel_id} and message_ts = ${message.message_ts}`;
           return;
         }
         const admin = (env.ADMIN_SLACK_USER_IDS ?? "").split(",").map(value => value.trim()).includes(candidate.user_id);
@@ -55,16 +68,29 @@ export async function processIncomingSlackReports(): Promise<void> {
           await tx`insert into outbox_jobs (report_id, target, action, report_version, dedupe_key)
             values (${report.id}, 'notion', 'publish', 1, ${`${report.id}:notion:publish:1`})`;
         }
-        await tx`update slack_incoming_reports set processed_at = now(), imported = true, report_id = ${report.id}
+        await tx`update slack_incoming_reports set processed_at = now(), imported = true, report_id = ${report.id}, last_error = null
           where channel_id = ${message.channel_id} and message_ts = ${message.message_ts}`;
       });
     } catch {
-      console.error("Slack report import failed; retained for retry", { channel: candidate.channel_id, ts: candidate.message_ts });
+      await sql`update slack_incoming_reports set
+          attempts = attempts + 1,
+          dead_at = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then now() else dead_at end,
+          available_at = case
+            when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then available_at
+            when attempts = 0 then now() + interval '5 seconds'
+            when attempts = 1 then now() + interval '15 seconds'
+            when attempts = 2 then now() + interval '30 seconds'
+            when attempts = 3 then now() + interval '1 minute'
+            else now() + interval '5 minutes'
+          end,
+          last_error = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then 'retry_exhausted' else 'import_failed' end
+        where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts}
+          and processed_at is null and dead_at is null`;
+      console.error("Slack report import failed; scheduled retry", { channel: candidate.channel_id, ts: candidate.message_ts });
     }
   }
   await processSlackReactions(client);
 }
-
 
 async function processSlackReactions(client: WebClient): Promise<void> {
   const sql = getDatabase();
@@ -72,18 +98,30 @@ async function processSlackReactions(client: WebClient): Promise<void> {
   const pending = await sql`select distinct reaction.channel_id, reaction.message_ts, reaction.user_id, binding.report_id
     from slack_report_reactions reaction
     join integration_bindings binding on binding.slack_channel_id = reaction.channel_id and binding.slack_message_ts = reaction.message_ts
-    where reaction.processed_at is null limit 20`;
+    where reaction.processed_at is null and reaction.dead_at is null and reaction.available_at <= now()
+    limit 20`;
   for (const reaction of pending) {
     try {
       const existing = await sql`select id from members where slack_team_id = ${env.SLACK_TEAM_ID!} and slack_user_id = ${reaction.user_id}`;
       const profile = existing.length ? undefined : (await client.users.info({ user: reaction.user_id })).user;
-      if (!existing.length && (!profile || profile.is_bot || profile.deleted)) continue;
+      if (!existing.length && (!profile || profile.is_bot || profile.deleted)) {
+        await sql`update slack_report_reactions set dead_at = now(), last_error = 'slack_user_unavailable'
+          where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
+            and user_id = ${reaction.user_id} and processed_at is null and dead_at is null`;
+        continue;
+      }
       await sql.begin(async (tx) => {
         // Web likes use the same report lock, keeping concurrent toggles consistent.
         const report = await tx`select id from reports where id = ${reaction.report_id} for update`;
-        if (!report.length) return;
+        if (!report.length) {
+          await tx`update slack_report_reactions set dead_at = now(), last_error = 'report_missing'
+            where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
+              and user_id = ${reaction.user_id} and processed_at is null and dead_at is null`;
+          return;
+        }
         const states = await tx`select reaction, active from slack_report_reactions
           where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts} and user_id = ${reaction.user_id}
+            and processed_at is null and dead_at is null
           order by reaction for update`;
         if (!existing.length) {
           const admin = (env.ADMIN_SLACK_USER_IDS ?? "").split(",").map(value => value.trim()).includes(reaction.user_id);
@@ -102,13 +140,27 @@ async function processSlackReactions(client: WebClient): Promise<void> {
         }
         // Mark only the rows locked above; newly arriving emojis remain pending.
         for (const state of states) {
-          await tx`update slack_report_reactions set processed_at = now()
+          await tx`update slack_report_reactions set processed_at = now(), last_error = null
             where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
               and user_id = ${reaction.user_id} and reaction = ${state.reaction}`;
         }
       });
     } catch {
-      console.error("Slack reaction sync failed; retained for retry", { channel: reaction.channel_id, ts: reaction.message_ts });
+      await sql`update slack_report_reactions set
+          attempts = attempts + 1,
+          dead_at = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then now() else dead_at end,
+          available_at = case
+            when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then available_at
+            when attempts = 0 then now() + interval '5 seconds'
+            when attempts = 1 then now() + interval '15 seconds'
+            when attempts = 2 then now() + interval '30 seconds'
+            when attempts = 3 then now() + interval '1 minute'
+            else now() + interval '5 minutes'
+          end,
+          last_error = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then 'retry_exhausted' else 'sync_failed' end
+        where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
+          and user_id = ${reaction.user_id} and processed_at is null and dead_at is null`;
+      console.error("Slack reaction sync failed; scheduled retry", { channel: reaction.channel_id, ts: reaction.message_ts });
     }
   }
 }

--- a/supabase/migrations/202609070002_slack_incoming_retry_state.sql
+++ b/supabase/migrations/202609070002_slack_incoming_retry_state.sql
@@ -1,0 +1,18 @@
+-- Retry/dead-letter state for Slack ingestion so poison events cannot block later work.
+alter table slack_incoming_reports add column if not exists attempts integer not null default 0 check (attempts >= 0);
+alter table slack_incoming_reports add column if not exists available_at timestamptz not null default now();
+alter table slack_incoming_reports add column if not exists last_error text;
+alter table slack_incoming_reports add column if not exists dead_at timestamptz;
+
+create index if not exists slack_incoming_reports_ready_idx
+  on slack_incoming_reports (available_at, created_at)
+  where processed_at is null and dead_at is null;
+
+alter table slack_report_reactions add column if not exists attempts integer not null default 0 check (attempts >= 0);
+alter table slack_report_reactions add column if not exists available_at timestamptz not null default now();
+alter table slack_report_reactions add column if not exists last_error text;
+alter table slack_report_reactions add column if not exists dead_at timestamptz;
+
+create index if not exists slack_report_reactions_ready_idx
+  on slack_report_reactions (available_at)
+  where processed_at is null and dead_at is null;


### PR DESCRIPTION
## Summary

Slack日報取り込み・Slackリアクション同期で、処理不能なイベントが`processed_at is null`のまま残り続け、`limit 20`のキューを占有して後続の正常イベントを阻害し得る問題を修正します。

特に、Slack上で削除済み/利用不能/Botのユーザーに紐づくイベントが永続pendingになるケースをDead Letterとして隔離します。

## Changes

- `slack_incoming_reports` に再試行状態を追加
  - `attempts`
  - `available_at`
  - `last_error`
  - `dead_at`
- `slack_report_reactions` にも同じ再試行状態を追加
- pending取得を `dead_at is null AND available_at <= now()` に限定
- Slackユーザーが恒久的に利用不能な場合は `slack_user_unavailable` として即Dead Letter化
- 一時的な処理失敗は最大5回までバックオフ再試行
  - 5秒
  - 15秒
  - 30秒
  - 1分
  - 5分
- 最大試行回数到達後は `retry_exhausted` として隔離
- リアクション対象の日報が消えている場合は `report_missing` として隔離
- Slackからより新しい編集/リアクションイベントが届いた場合は、retry/dead状態をリセットして再処理可能にする
- ready queue向けpartial indexを追加

## Why

従来は次のようなコードパスで処理不能イベントが永久に残りました。

```ts
if (!existing.length && (!profile || profile.is_bot || profile.deleted)) continue;
```

一方pending取得は、

```sql
where processed_at is null
order by created_at
limit 20
```

だったため、poison eventが蓄積すると正常なイベントまで処理されなくなる可能性がありました。

このPRでは、成功・再試行待ち・Dead Letterを明確に分離し、1件の異常イベントがキュー全体を塞がない設計にします。

## Migration

追加migration:

```text
supabase/migrations/202609070002_slack_incoming_retry_state.sql
```

アプリデプロイ前にDB migrationを適用してください。

## Scope

今回のPRでは管理画面のDead Letter UIや手動再送UIまでは追加しません。`dead_at` / `last_error`をDBに保持し、後続の運用UI追加が可能な状態までを対象とします。

## Target

`fix/slack-incoming-dead-letter` → `main`
