### PR TITLE
security: fail closed when Demo Mode is enabled in production

### DIFF
--- a/docs/production-safety.md
+++ b/docs/production-safety.md
@@ -1,0 +1,30 @@
+# Production safety
+
+Hanabi LOGの本番環境ではDemo Modeを使用しません。
+
+## Demo Mode
+
+`DEMO_MODE=true` はローカル開発・テスト用途だけで使用します。
+
+productionで `DEMO_MODE=true` が設定されている場合、アプリは起動時検証で失敗します。また、`isDemoMode` 自体もproductionでは常に `false` になるため、デモ用Admin認証へフォールバックしません。
+
+Productionでは明示的に次を設定してください。
+
+```text
+DEMO_MODE=false
+```
+
+あわせて、`assertProductionEnv()` が要求する本番用環境変数をすべて設定します。
+
+## デプロイ前確認
+
+- `NODE_ENV=production`
+- `DEMO_MODE=false`
+- Slack / Supabase / Notion / Cron用の必須環境変数が設定済み
+- secretやtokenをGit・ログ・公開artifactへ出していない
+- `npm run lint`
+- `npm run typecheck`
+- `npm test`
+- `npm run build`
+
+Previewでデモ表示が必要な場合も、production環境へ `DEMO_MODE=true` を持ち込まないでください。デモ環境はdevelopment/testとして明確に分離します。

--- a/src/server/env.test.ts
+++ b/src/server/env.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertDemoModeAllowedInProduction,
+  resolveDemoMode,
+} from "./env";
+
+describe("demo mode deployment safety", () => {
+  it("never resolves demo mode in production", () => {
+    expect(
+      resolveDemoMode({
+        nodeEnv: "production",
+        demoMode: "true",
+        databaseUrl: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it("keeps explicit demo mode available outside production", () => {
+    expect(
+      resolveDemoMode({
+        nodeEnv: "development",
+        demoMode: "true",
+        databaseUrl: undefined,
+      }),
+    ).toBe(true);
+  });
+
+  it("keeps the credential-free local demo fallback outside production", () => {
+    expect(
+      resolveDemoMode({
+        nodeEnv: "test",
+        demoMode: undefined,
+        databaseUrl: undefined,
+      }),
+    ).toBe(true);
+    expect(
+      resolveDemoMode({
+        nodeEnv: "development",
+        demoMode: undefined,
+        databaseUrl: "postgresql://localhost/hanabi",
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects an explicit production demo configuration", () => {
+    expect(() =>
+      assertDemoModeAllowedInProduction({
+        nodeEnv: "production",
+        demoMode: "true",
+      }),
+    ).toThrow("DEMO_MODE must never be enabled in production");
+  });
+
+  it("allows normal production and non-production configurations", () => {
+    expect(() =>
+      assertDemoModeAllowedInProduction({
+        nodeEnv: "production",
+        demoMode: "false",
+      }),
+    ).not.toThrow();
+    expect(() =>
+      assertDemoModeAllowedInProduction({
+        nodeEnv: "development",
+        demoMode: "true",
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/server/env.test.ts
+++ b/src/server/env.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+
 import {
   assertDemoModeAllowedInProduction,
   resolveDemoMode,

--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -36,14 +36,47 @@ const schema = z.object({
   CRON_SECRET: optional,
 });
 
+type NodeEnvironment = z.infer<typeof schema>["NODE_ENV"];
+type DemoModeValue = z.infer<typeof schema>["DEMO_MODE"];
+
+interface DemoModeRuntime {
+  nodeEnv: NodeEnvironment;
+  demoMode?: DemoModeValue;
+  databaseUrl?: string;
+}
+
+export function resolveDemoMode({
+  nodeEnv,
+  demoMode,
+  databaseUrl,
+}: DemoModeRuntime): boolean {
+  if (nodeEnv === "production") return false;
+  return demoMode === "true" || (!demoMode && !databaseUrl);
+}
+
+export function assertDemoModeAllowedInProduction({
+  nodeEnv,
+  demoMode,
+}: Pick<DemoModeRuntime, "nodeEnv" | "demoMode">): void {
+  if (nodeEnv === "production" && demoMode === "true") {
+    throw new Error("DEMO_MODE must never be enabled in production");
+  }
+}
+
 export const env = schema.parse(process.env);
 
-export const isDemoMode =
-  env.DEMO_MODE === "true" ||
-  (env.NODE_ENV !== "production" && !env.DEMO_MODE && !env.DATABASE_URL);
+export const isDemoMode = resolveDemoMode({
+  nodeEnv: env.NODE_ENV,
+  demoMode: env.DEMO_MODE,
+  databaseUrl: env.DATABASE_URL,
+});
 
 export function assertProductionEnv(): void {
-  if (env.NODE_ENV !== "production" || isDemoMode) return;
+  assertDemoModeAllowedInProduction({
+    nodeEnv: env.NODE_ENV,
+    demoMode: env.DEMO_MODE,
+  });
+  if (env.NODE_ENV !== "production") return;
   const required = [
     "APP_BASE_URL",
     "AUTH_SECRET",


### PR DESCRIPTION
## Summary

Production環境でDemo Modeが誤って有効化されても、デモ用Admin認証へフォールバックしないようfail-closed化します。

Closes #31

## Changes

- `isDemoMode`をproductionでは常に`false`に変更
- `NODE_ENV=production`かつ`DEMO_MODE=true`を起動時検証で明示的に拒否
- development/testの明示Demo Modeと資格情報なしローカルfallbackは維持
- Unit testを追加
- production運用ルールを`docs/production-safety.md`へ追加

## Security intent

防御を二重化しています。

1. Runtime判定: productionでは`isDemoMode`がtrueにならない
2. Startup validation: productionで`DEMO_MODE=true`なら起動を失敗させる

これにより、起動時検証経路への依存だけでなく、Demo Mode判定そのものもfail-closedになります。

## Tests

追加したUnit testでは以下を確認します。

- production + `DEMO_MODE=true`でもDemo Modeへ入らない
- production + `DEMO_MODE=true`を明示拒否する
- developmentではDemo Modeを利用できる
- 資格情報なしローカルfallbackを維持する
- 通常production設定を拒否しない

## Target

`security/production-demo-fail-closed` → `main`

`main`へ直接pushしない。
