### PR TITLE
security: harden CI supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:30"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,10 @@ jobs:
       ADMIN_SLACK_USER_IDS: U_CI
       CRON_SECRET: ci-only-cron-secret
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,29 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "17 18 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze JavaScript/TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: github/codeql-action/init@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+        with:
+          languages: javascript-typescript
+      - uses: github/codeql-action/analyze@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -8,6 +8,11 @@ permissions:
 
 jobs:
   dependency-review:
+    # Dependency Review requires GitHub's Dependency graph. Running the action
+    # before that repository setting is enabled makes every PR fail for a
+    # configuration reason, so enforcement is opt-in until Admin completes the
+    # repository-side setup.
+    if: ${{ vars.DEPENDENCY_REVIEW_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: Dependency Review
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        with:
+          fail-on-severity: high

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -1,0 +1,30 @@
+# CI / Supply Chain Security
+
+Hanabi LOGのCI/CDでは、依存先の変更がそのまま実行コードになることを前提に、GitHub Actionsとnpm依存関係を継続監視します。
+
+## GitHub Actions
+
+- Workflow内のthird-party / GitHub公式Actionは、可変tagだけではなくfull commit SHAへpinする。
+- SHA末尾のコメントに確認時のrelease/tagを残す。
+- Actionを更新する際は、公式repositoryのrelease/tagが指すcommitを確認してからSHAを更新する。
+- Workflow tokenはjobに必要な最小permissionsだけを付与する。
+- checkoutではCIからpushする必要がない限り`persist-credentials: false`を使う。
+
+## Automated checks
+
+- `CI`: lint / typecheck / unit tests / build / E2E。
+- `CodeQL`: JavaScript/TypeScriptをPR、main push、週次で解析する。
+- `Dependency Review`: PRで新しく導入されるHigh以上の既知脆弱性をblockする。
+- `Dependabot`: npmとGitHub Actionsを週次で更新候補として提出する。
+
+## Dependency updates
+
+自動更新PRであっても、CIが成功する前にmergeしない。Major updateはrelease notes、breaking changes、migration要否を確認する。認証、DB、Slack/Notion、Storage、Next.js関連依存は特に手動レビューする。
+
+## Pin rotation
+
+SHA pinは固定したまま放置しない。Dependabotまたは定期レビューで新しいreleaseを確認し、更新PRを通常のCIに通す。未知のforkや保守停止Actionへ置き換えない。
+
+## Secrets
+
+CI fixtureには実token、メール、日報本文、signed URL、本番DB接続情報を入れない。GitHub Actions logやartifactへ秘密値を出力しない。

--- a/docs/supply-chain-security.md
+++ b/docs/supply-chain-security.md
@@ -17,6 +17,19 @@ Hanabi LOGのCI/CDでは、依存先の変更がそのまま実行コードに�
 - `Dependency Review`: PRで新しく導入されるHigh以上の既知脆弱性をblockする。
 - `Dependabot`: npmとGitHub Actionsを週次で更新候補として提出する。
 
+## Dependency Review activation
+
+Dependency ReviewはGitHubのDependency graphが有効であることを前提とします。Dependency graphが無効な状態でActionを実行すると、脆弱性の有無ではなくrepository設定不足でPRが失敗します。
+
+そのため、workflowはrepository variable `DEPENDENCY_REVIEW_ENABLED=true` のときだけ実行します。Repository Adminは次の順序で有効化します。
+
+1. GitHub repository settingsでDependency graphを有効化する。
+2. Repository variable `DEPENDENCY_REVIEW_ENABLED=true`を設定する。
+3. テストPRを作り、`Dependency Review` jobがskipではなく実行されて成功することを確認する。
+4. main ruleset / branch protectionのrequired checkへDependency Reviewを追加する。
+
+有効化前はCodeQL・CI・Dependabot・SHA pinは有効ですが、Dependency Reviewは強制されていないため、Issue #37を完了扱いにしません。
+
 ## Dependency updates
 
 自動更新PRであっても、CIが成功する前にmergeしない。Major updateはrelease notes、breaking changes、migration要否を確認する。認証、DB、Slack/Notion、Storage、Next.js関連依存は特に手動レビューする。


### PR DESCRIPTION
## Summary

CI/CDのサプライチェーン防御を強化します。

Refs #37

## Changes

- `actions/checkout` / `actions/setup-node`をfull commit SHAへpin
- checkout credentialsを保持しない設定へ変更
- CodeQL JavaScript/TypeScript解析を追加（PR / main / weekly）
- Dependency Review workflowを追加
- Dependabotでnpm / GitHub Actionsの週次更新を有効化
- least-privilege permissionsを明示
- `docs/supply-chain-security.md`で更新・pin運用を文書化

## Dependency Review activation

このrepositoryでは現在Dependency graphが無効なため、Dependency Review Actionをそのまま必須実行すると全PRが設定理由で失敗します。

そのため、Dependency Review jobはrepository variable `DEPENDENCY_REVIEW_ENABLED=true` のときだけ実行します。

有効化手順:
1. Repository AdminがGitHubのDependency graphをONにする
2. Repository variable `DEPENDENCY_REVIEW_ENABLED=true`を設定する
3. PRでDependency Reviewが成功し、High以上の新規既知脆弱性をblockすることを確認する

このactivationが完了するまではIssue #37をcloseしません。

## Notes

Action SHAは公式repositoryの対応release/tagが指すcommitを確認して固定しています。SBOMについては、このPRでは新たな外部Actionを増やして攻撃面を広げるより、CodeQL・Dependency Review・Dependabot・SHA pinを優先します。

## Target

`security/ci-supply-chain` → `main`
