### PR TITLE
refactor: use Asia/Tokyo for report date boundaries

### DIFF
--- a/src/lib/timezone.test.ts
+++ b/src/lib/timezone.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { HANABI_TIME_ZONE, toHanabiReportDate } from "./timezone";
+
+describe("Hanabi timezone", () => {
+  it("uses the IANA Asia/Tokyo timezone", () => {
+    expect(HANABI_TIME_ZONE).toBe("Asia/Tokyo");
+  });
+
+  it("moves to the next report date at the Tokyo day boundary", () => {
+    expect(toHanabiReportDate(new Date("2026-09-06T14:59:59.999Z"))).toBe("2026-09-06");
+    expect(toHanabiReportDate(new Date("2026-09-06T15:00:00.000Z"))).toBe("2026-09-07");
+  });
+
+  it("handles year boundaries using timezone rules", () => {
+    expect(toHanabiReportDate(new Date("2026-12-31T14:59:59.999Z"))).toBe("2026-12-31");
+    expect(toHanabiReportDate(new Date("2026-12-31T15:00:00.000Z"))).toBe("2027-01-01");
+  });
+
+  it("rejects invalid instants", () => {
+    expect(() => toHanabiReportDate(new Date(Number.NaN))).toThrow("Invalid date");
+  });
+});

--- a/src/lib/timezone.ts
+++ b/src/lib/timezone.ts
@@ -1,0 +1,24 @@
+export const HANABI_TIME_ZONE = "Asia/Tokyo";
+
+const reportDateFormatter = new Intl.DateTimeFormat("en-CA", {
+  timeZone: HANABI_TIME_ZONE,
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
+/**
+ * Converts an instant to the Hanabi operating date using the IANA timezone
+ * database instead of assuming Japan is permanently UTC+09:00.
+ */
+export function toHanabiReportDate(value: Date): string {
+  if (Number.isNaN(value.getTime())) throw new Error("Invalid date");
+
+  const parts = reportDateFormatter.formatToParts(value);
+  const year = parts.find((part) => part.type === "year")?.value;
+  const month = parts.find((part) => part.type === "month")?.value;
+  const day = parts.find((part) => part.type === "day")?.value;
+
+  if (!year || !month || !day) throw new Error("Unable to format Hanabi report date");
+  return `${year}-${month}-${day}`;
+}

--- a/src/server/integrations/slack-incoming-store.ts
+++ b/src/server/integrations/slack-incoming-store.ts
@@ -3,6 +3,7 @@ import { WebClient } from "@slack/web-api";
 import { getDatabase } from "@/server/db/client";
 import { env, isDemoMode } from "@/server/env";
 import { resolveReportTitle } from "@/lib/report-title";
+import { toHanabiReportDate } from "@/lib/timezone";
 
 export async function processIncomingSlackReports(): Promise<void> {
   if (isDemoMode || !env.SLACK_TEAM_ID || !env.SLACK_BOT_TOKEN) return;
@@ -43,7 +44,7 @@ export async function processIncomingSlackReports(): Promise<void> {
         const [member] = await tx`select * from members where slack_team_id = ${env.SLACK_TEAM_ID!} and slack_user_id = ${candidate.user_id}`;
         const published = member.is_active || member.role === "admin";
         const occurredAt = new Date(Number(message.message_ts) * 1000);
-        const reportDate = new Date(occurredAt.getTime() + 9 * 3600000).toISOString().slice(0, 10);
+        const reportDate = toHanabiReportDate(occurredAt);
         const [report] = await tx`insert into reports (author_id, report_date, title, summary, activity_area, content_category, activity_text, status, published_at)
           values (${member.id}, ${reportDate}, ${resolveReportTitle("", member.display_name)}, ${Array.from(body).slice(0, 100).join("")}, 'その他', '進捗', ${body}, ${published ? "published" : "pending_approval"}, ${published ? occurredAt : null}) returning id`;
         const permalink = `https://app.slack.com/archives/${message.channel_id}/p${message.message_ts.replace(".", "")}`;


### PR DESCRIPTION
## Summary

Slack投稿時刻から日報日付を決める処理を、固定`UTC+9`加算からIANA timezone `Asia/Tokyo`へ移行します。

Closes #42

## Changes

- `src/lib/timezone.ts`へHanabi共通timezone utilityを追加
- Slack取り込みの日付判定を`toHanabiReportDate()`へ置換
- UTC日跨ぎ・年跨ぎ境界のUnit testを追加
- DBのinstant/timestamptz保存方針は変更せず、日付境界の解釈だけAsia/Tokyoへ統一

## Why

固定offsetでは将来の時刻制度変更へ追従できません。IANA timezone databaseを使用することで、長期運用時にもtimezone ruleをruntime側で追従できます。

## Target

`refactor/asia-tokyo-timezone` → `main`
