### PR TITLE
security: add append-only audit log

### DIFF
--- a/src/app/api/integrations/notion/callback/route.ts
+++ b/src/app/api/integrations/notion/callback/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { recordAuditEvent } from "@/server/audit";
 import { requireCurrentUser } from "@/server/auth";
 import { AppError } from "@/server/errors";
 import {
@@ -32,6 +33,13 @@ export async function GET(request: Request): Promise<Response> {
       );
     }
     await exchangeNotionOAuthCode(code, user.id);
+    await recordAuditEvent({
+      actor: user,
+      action: "notion.connected",
+      targetType: "integration",
+      targetId: "notion",
+      after: { connected: true },
+    });
     return adminRedirect(request, "connected");
   } catch (error) {
     const reason = error instanceof AppError ? error.code : "OAUTH_FAILED";

--- a/src/app/api/integrations/notion/route.ts
+++ b/src/app/api/integrations/notion/route.ts
@@ -1,11 +1,12 @@
 import { apiResponse } from "@/app/api/_shared";
+import { recordAuditEvent } from "@/server/audit";
 import { requireCurrentUser } from "@/server/auth";
 import { isDemoMode } from "@/server/env";
 import { AppError } from "@/server/errors";
 import { revokeNotionOAuthConnection } from "@/server/integrations/notion-oauth";
 import { getNotionOAuthConnectionSummary } from "@/server/integrations/notion-oauth-store";
 
-async function requireAdmin(): Promise<void> {
+async function requireAdmin() {
   const user = await requireCurrentUser();
   if (user.role !== "admin") {
     throw new AppError(
@@ -14,6 +15,7 @@ async function requireAdmin(): Promise<void> {
       403,
     );
   }
+  return user;
 }
 
 export async function GET(): Promise<Response> {
@@ -33,8 +35,17 @@ export async function GET(): Promise<Response> {
 
 export async function DELETE(): Promise<Response> {
   return apiResponse(async () => {
-    await requireAdmin();
+    const actor = await requireAdmin();
+    const before = isDemoMode ? null : await getNotionOAuthConnectionSummary();
     await revokeNotionOAuthConnection();
+    await recordAuditEvent({
+      actor,
+      action: "notion.disconnected",
+      targetType: "integration",
+      targetId: "notion",
+      before: before ? { connected: before.connected } : null,
+      after: { connected: false },
+    });
     return new Response(null, { status: 204 });
   });
 }

--- a/src/app/api/members/[id]/route.ts
+++ b/src/app/api/members/[id]/route.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { apiResponse, requestJson } from "@/app/api/_shared";
+import { recordAuditEvent } from "@/server/audit";
 import { requireCurrentUser } from "@/server/auth";
 import { AppError } from "@/server/errors";
 import { toPublicMember } from "@/server/members";
@@ -25,25 +26,38 @@ export async function PATCH(request: Request, context: RouteContext): Promise<Re
     const memberId = memberIdSchema.parse((await context.params).id);
     const update = memberUpdateSchema.parse(await requestJson(request));
     const repository = getReportRepository();
+    const target = await repository.getMember(memberId);
     let member;
+    let auditAction: string;
     if ("role" in update) {
       if (memberId === actor.id && update.role === "member") {
         throw new AppError("SELF_DEMOTION_FORBIDDEN", "自分自身をMemberへ変更することはできません", 409);
       }
       member = await repository.setMemberRole(memberId, update.role);
+      auditAction = "member.role_changed";
     } else {
       if (memberId === actor.id && !update.isActive) {
         throw new AppError("SELF_DEACTIVATION_FORBIDDEN", "自分自身をInactiveへ変更することはできません", 409);
       }
-      const target = await repository.getMember(memberId);
       if (target?.role === "admin" && !update.isActive) {
         throw new AppError("ADMIN_DEACTIVATION_FORBIDDEN", "AdminはInactiveへ変更できません", 409);
       }
       member = target
         ? await repository.setMemberActivity(memberId, update.isActive)
         : null;
+      auditAction = update.isActive ? "member.activated" : "member.deactivated";
     }
     if (!member) throw new AppError("NOT_FOUND", "メンバーが見つかりません", 404);
+
+    await recordAuditEvent({
+      actor,
+      action: auditAction,
+      targetType: "member",
+      targetId: memberId,
+      before: target ? { role: target.role, isActive: target.isActive } : null,
+      after: { role: member.role, isActive: member.isActive },
+    });
+
     return Response.json(toPublicMember(member), {
       headers: { "Cache-Control": "private, no-store" },
     });
@@ -74,7 +88,9 @@ export async function DELETE(_request: Request, context: RouteContext): Promise<
       throw new AppError("SELF_DELETE_FORBIDDEN", "自分自身を削除することはできません", 409);
     }
 
-    const result = await getReportRepository().deleteMember(memberId);
+    const repository = getReportRepository();
+    const target = await repository.getMember(memberId);
+    const result = await repository.deleteMember(memberId);
     if (result === "not_found") {
       throw new AppError("NOT_FOUND", "メンバーが見つかりません", 404);
     }
@@ -85,6 +101,15 @@ export async function DELETE(_request: Request, context: RouteContext): Promise<
         409,
       );
     }
+
+    await recordAuditEvent({
+      actor,
+      action: "member.deleted",
+      targetType: "member",
+      targetId: memberId,
+      before: target ? { role: target.role, isActive: target.isActive } : null,
+    });
+
     return new Response(null, { status: 204 });
   });
 }

--- a/src/app/api/reports/[id]/approve/route.ts
+++ b/src/app/api/reports/[id]/approve/route.ts
@@ -1,4 +1,5 @@
 import { apiResponse, reportId, reportResponse } from "@/app/api/_shared";
+import { recordAuditEvent } from "@/server/audit";
 import { requireCurrentUser } from "@/server/auth";
 import { scheduleReportJobs } from "@/server/integrations/schedule";
 import { getReportRepository } from "@/server/repositories";
@@ -13,6 +14,13 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
     const id = reportId((await context.params).id);
     const repository = getReportRepository();
     const report = await repository.approveReport(id, actor);
+    await recordAuditEvent({
+      actor,
+      action: "report.approved",
+      targetType: "report",
+      targetId: id,
+      after: { status: report.status, version: report.version },
+    });
     scheduleReportJobs(id);
     return reportResponse(report, request);
   });

--- a/src/app/api/reports/[id]/archive/route.ts
+++ b/src/app/api/reports/[id]/archive/route.ts
@@ -1,4 +1,5 @@
 import { apiResponse, reportId, reportResponse } from "@/app/api/_shared";
+import { recordAuditEvent } from "@/server/audit";
 import { requireCurrentUser } from "@/server/auth";
 import { scheduleReportJobs } from "@/server/integrations/schedule";
 import { getReportRepository } from "@/server/repositories";
@@ -12,6 +13,13 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
     const user = await requireCurrentUser();
     const id = reportId((await context.params).id);
     const report = await getReportRepository().archiveReport(id, user);
+    await recordAuditEvent({
+      actor: user,
+      action: "report.archived",
+      targetType: "report",
+      targetId: id,
+      after: { status: report.status, version: report.version },
+    });
     scheduleReportJobs(id);
     return reportResponse(report, request);
   });

--- a/src/app/api/reports/[id]/integrations/[target]/retry/route.ts
+++ b/src/app/api/reports/[id]/integrations/[target]/retry/route.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { apiResponse, reportId, reportResponse } from "@/app/api/_shared";
+import { recordAuditEvent } from "@/server/audit";
 import { requireCurrentUser } from "@/server/auth";
 import { scheduleReportJobs } from "@/server/integrations/schedule";
 import { getReportRepository } from "@/server/repositories";
@@ -17,6 +18,13 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
     const id = reportId(parameters.id);
     const target = targetSchema.parse(parameters.target);
     const report = await getReportRepository().requestIntegrationRetry(id, target, user);
+    await recordAuditEvent({
+      actor: user,
+      action: "integration.retry_requested",
+      targetType: "report_integration",
+      targetId: `${id}:${target}`,
+      metadata: { reportId: id, integrationTarget: target },
+    });
     scheduleReportJobs(id);
     return reportResponse(report, request);
   });

--- a/src/app/api/reports/[id]/publish/route.ts
+++ b/src/app/api/reports/[id]/publish/route.ts
@@ -4,6 +4,7 @@ import {
   reportId,
   reportResponse,
 } from "@/app/api/_shared";
+import { recordAuditEvent } from "@/server/audit";
 import { requireCurrentUser } from "@/server/auth";
 import { scheduleReportJobs } from "@/server/integrations/schedule";
 import { getReportRepository } from "@/server/repositories";
@@ -21,6 +22,13 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
       user,
       idempotencyKey(request),
     );
+    await recordAuditEvent({
+      actor: user,
+      action: report.status === "published" ? "report.published" : "report.publish_requested",
+      targetType: "report",
+      targetId: id,
+      after: { status: report.status, version: report.version },
+    });
     if (report.status === "published") scheduleReportJobs(id);
     return reportResponse(report, request);
   });

--- a/src/app/api/reports/[id]/restore/route.ts
+++ b/src/app/api/reports/[id]/restore/route.ts
@@ -1,4 +1,5 @@
 import { apiResponse, reportId, reportResponse } from "@/app/api/_shared";
+import { recordAuditEvent } from "@/server/audit";
 import { requireCurrentUser } from "@/server/auth";
 import { scheduleReportJobs } from "@/server/integrations/schedule";
 import { getReportRepository } from "@/server/repositories";
@@ -12,6 +13,13 @@ export async function POST(request: Request, context: RouteContext): Promise<Res
     const user = await requireCurrentUser();
     const id = reportId((await context.params).id);
     const report = await getReportRepository().restoreReport(id, user);
+    await recordAuditEvent({
+      actor: user,
+      action: "report.restored",
+      targetType: "report",
+      targetId: id,
+      after: { status: report.status, version: report.version },
+    });
     scheduleReportJobs(id);
     return reportResponse(report, request);
   });

--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -9,6 +9,7 @@ import {
   reportResponse,
   requestJson,
 } from "@/app/api/_shared";
+import { recordAuditEvent } from "@/server/audit";
 import { requireCurrentUser } from "@/server/auth";
 import { scheduleReportJobs } from "@/server/integrations/schedule";
 import { getReportRepository } from "@/server/repositories";
@@ -51,6 +52,14 @@ export async function PATCH(request: Request, context: RouteContext): Promise<Re
       input.version,
       input.report,
     );
+    await recordAuditEvent({
+      actor: user,
+      action: "report.edited",
+      targetType: "report",
+      targetId: id,
+      before: { status: existing.status, version: existing.version },
+      after: { status: report.status, version: report.version },
+    });
     if (report.status === "published") scheduleReportJobs(id);
     return reportResponse(report, request);
   });
@@ -79,6 +88,13 @@ export async function DELETE(_request: Request, context: RouteContext): Promise<
       await deleteReportResources(report);
       await repository.deleteReport(id, user);
     }
+    await recordAuditEvent({
+      actor: user,
+      action: "report.deleted",
+      targetType: "report",
+      targetId: id,
+      before: { status: report.status, version: report.version },
+    });
     return new Response(null, {
       status: 204,
       headers: { "Cache-Control": "private, no-store" },

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -7,6 +7,7 @@ import {
   reportResponse,
   requestJson,
 } from "@/app/api/_shared";
+import { recordAuditEvent } from "@/server/audit";
 import { requireCurrentUser } from "@/server/auth";
 import { getReportRepository } from "@/server/repositories";
 import { resolveReportTitle } from "@/lib/report-title";
@@ -43,6 +44,13 @@ export async function POST(request: Request): Promise<Response> {
       input,
       idempotencyKey(request),
     );
+    await recordAuditEvent({
+      actor: user,
+      action: "report.created",
+      targetType: "report",
+      targetId: report.id,
+      after: { status: report.status, version: report.version },
+    });
     return reportResponse(report, request, 201);
   });
 }

--- a/src/server/audit.test.ts
+++ b/src/server/audit.test.ts
@@ -1,0 +1,36 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/server/db/client", () => ({ getDatabase: vi.fn() }));
+vi.mock("@/server/env", () => ({ isDemoMode: true }));
+
+let sanitizeAuditValue: typeof import("./audit").sanitizeAuditValue;
+
+beforeAll(async () => {
+  ({ sanitizeAuditValue } = await import("./audit"));
+});
+
+describe("audit value sanitization", () => {
+  it("redacts sensitive keys recursively", () => {
+    expect(
+      sanitizeAuditValue({
+        action: "notion.connected",
+        accessToken: "secret-token",
+        nested: { client_secret: "secret", safe: "ok" },
+      }),
+    ).toEqual({
+      action: "notion.connected",
+      accessToken: "[REDACTED]",
+      nested: { client_secret: "[REDACTED]", safe: "ok" },
+    });
+  });
+
+  it("bounds strings and nesting depth", () => {
+    const result = sanitizeAuditValue({ value: "x".repeat(2100) }) as { value: string };
+    expect(result.value.length).toBeLessThanOrEqual(2001);
+
+    let value: unknown = "leaf";
+    for (let index = 0; index < 12; index += 1) value = { child: value };
+    expect(JSON.stringify(sanitizeAuditValue(value))).toContain("[MAX_DEPTH]");
+  });
+});

--- a/src/server/audit.ts
+++ b/src/server/audit.ts
@@ -45,7 +45,10 @@ export async function recordAuditEvent(input: AuditEventInput): Promise<void> {
   const sql = getDatabase();
   const before = input.before === undefined ? null : sanitizeAuditValue(input.before);
   const after = input.after === undefined ? null : sanitizeAuditValue(input.after);
-  const metadata = sanitizeAuditValue(input.metadata ?? {}) as Record<string, unknown>;
+  const metadata = sanitizeAuditValue(input.metadata ?? {});
+  const beforeJson = before === null ? null : JSON.stringify(before);
+  const afterJson = after === null ? null : JSON.stringify(after);
+  const metadataJson = JSON.stringify(metadata);
 
   await sql`insert into audit_events
     (actor_member_id, actor_role, action, target_type, target_id, source, request_id, before_json, after_json, metadata_json)
@@ -57,8 +60,8 @@ export async function recordAuditEvent(input: AuditEventInput): Promise<void> {
       ${input.targetId ?? null},
       ${input.source ?? "web"},
       ${input.requestId ?? null},
-      ${before ? sql.json(before) : null},
-      ${after ? sql.json(after) : null},
-      ${sql.json(metadata)}
+      ${beforeJson}::jsonb,
+      ${afterJson}::jsonb,
+      ${metadataJson}::jsonb
     )`;
 }

--- a/src/server/audit.ts
+++ b/src/server/audit.ts
@@ -1,6 +1,3 @@
-import { getDatabase } from "@/server/db/client";
-import { env, isDemoMode } from "@/server/env";
-
 const SENSITIVE_KEY = /(token|secret|password|authorization|cookie|credential|private[_-]?key|api[_-]?key)/i;
 
 export interface AuditActor {
@@ -37,10 +34,17 @@ export function sanitizeAuditValue(value: unknown, depth = 0): unknown {
   return String(value);
 }
 
+function isLocalDemoMode(): boolean {
+  if (process.env.NODE_ENV === "production") return false;
+  if (process.env.DEMO_MODE === "true") return true;
+  return !process.env.DEMO_MODE && !process.env.DATABASE_URL;
+}
+
 export async function recordAuditEvent(input: AuditEventInput): Promise<void> {
-  // Unit/API tests use repository doubles and must not require a live audit DB.
-  // The sanitizer is tested directly; DB persistence is covered by migration/production integration.
-  if (env.NODE_ENV === "test" || isDemoMode) return;
+  // Unit/API tests use repository doubles and must not import the live DB module.
+  // DB access is loaded lazily only for real persistence paths.
+  if (process.env.NODE_ENV === "test" || isLocalDemoMode()) return;
+  const { getDatabase } = await import("@/server/db/client");
   const sql = getDatabase();
   const before = input.before === undefined ? null : sanitizeAuditValue(input.before);
   const after = input.after === undefined ? null : sanitizeAuditValue(input.after);

--- a/src/server/audit.ts
+++ b/src/server/audit.ts
@@ -1,0 +1,62 @@
+import "server-only";
+import { getDatabase } from "@/server/db/client";
+import { isDemoMode } from "@/server/env";
+
+const SENSITIVE_KEY = /(token|secret|password|authorization|cookie|credential|private[_-]?key|api[_-]?key)/i;
+
+export interface AuditActor {
+  id: string;
+  role?: string | null;
+}
+
+export interface AuditEventInput {
+  actor: AuditActor;
+  action: string;
+  targetType: string;
+  targetId?: string | null;
+  source?: string;
+  requestId?: string | null;
+  before?: unknown;
+  after?: unknown;
+  metadata?: Record<string, unknown>;
+}
+
+export function sanitizeAuditValue(value: unknown, depth = 0): unknown {
+  if (depth > 8) return "[MAX_DEPTH]";
+  if (value === null || value === undefined) return value ?? null;
+  if (typeof value === "string") return value.length > 2000 ? `${value.slice(0, 2000)}…` : value;
+  if (typeof value === "number" || typeof value === "boolean") return value;
+  if (value instanceof Date) return value.toISOString();
+  if (Array.isArray(value)) return value.slice(0, 100).map((item) => sanitizeAuditValue(item, depth + 1));
+  if (typeof value === "object") {
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(value as Record<string, unknown>).slice(0, 100)) {
+      sanitized[key] = SENSITIVE_KEY.test(key) ? "[REDACTED]" : sanitizeAuditValue(child, depth + 1);
+    }
+    return sanitized;
+  }
+  return String(value);
+}
+
+export async function recordAuditEvent(input: AuditEventInput): Promise<void> {
+  if (isDemoMode) return;
+  const sql = getDatabase();
+  const before = input.before === undefined ? null : sanitizeAuditValue(input.before);
+  const after = input.after === undefined ? null : sanitizeAuditValue(input.after);
+  const metadata = sanitizeAuditValue(input.metadata ?? {}) as Record<string, unknown>;
+
+  await sql`insert into audit_events
+    (actor_member_id, actor_role, action, target_type, target_id, source, request_id, before_json, after_json, metadata_json)
+    values (
+      ${input.actor.id}::uuid,
+      ${input.actor.role ?? null},
+      ${input.action},
+      ${input.targetType},
+      ${input.targetId ?? null},
+      ${input.source ?? "web"},
+      ${input.requestId ?? null},
+      ${before ? sql.json(before) : null},
+      ${after ? sql.json(after) : null},
+      ${sql.json(metadata)}
+    )`;
+}

--- a/src/server/audit.ts
+++ b/src/server/audit.ts
@@ -1,6 +1,6 @@
 import "server-only";
 import { getDatabase } from "@/server/db/client";
-import { isDemoMode } from "@/server/env";
+import { env, isDemoMode } from "@/server/env";
 
 const SENSITIVE_KEY = /(token|secret|password|authorization|cookie|credential|private[_-]?key|api[_-]?key)/i;
 
@@ -39,7 +39,9 @@ export function sanitizeAuditValue(value: unknown, depth = 0): unknown {
 }
 
 export async function recordAuditEvent(input: AuditEventInput): Promise<void> {
-  if (isDemoMode) return;
+  // Unit/API tests use repository doubles and must not require a live audit DB.
+  // The sanitizer is tested directly; DB persistence is covered by migration/production integration.
+  if (env.NODE_ENV === "test" || isDemoMode) return;
   const sql = getDatabase();
   const before = input.before === undefined ? null : sanitizeAuditValue(input.before);
   const after = input.after === undefined ? null : sanitizeAuditValue(input.after);

--- a/src/server/audit.ts
+++ b/src/server/audit.ts
@@ -1,4 +1,3 @@
-import "server-only";
 import { getDatabase } from "@/server/db/client";
 import { env, isDemoMode } from "@/server/env";
 

--- a/supabase/migrations/202609070004_audit_events.sql
+++ b/supabase/migrations/202609070004_audit_events.sql
@@ -1,0 +1,44 @@
+create table if not exists audit_events (
+  id uuid primary key default gen_random_uuid(),
+  occurred_at timestamptz not null default now(),
+  actor_member_id uuid,
+  actor_role text,
+  action text not null check (length(action) between 1 and 120),
+  target_type text not null check (length(target_type) between 1 and 80),
+  target_id text,
+  source text not null default 'web' check (length(source) between 1 and 40),
+  request_id text,
+  before_json jsonb,
+  after_json jsonb,
+  metadata_json jsonb not null default '{}'::jsonb
+);
+
+create index if not exists audit_events_occurred_at_idx
+  on audit_events (occurred_at desc);
+create index if not exists audit_events_actor_idx
+  on audit_events (actor_member_id, occurred_at desc);
+create index if not exists audit_events_target_idx
+  on audit_events (target_type, target_id, occurred_at desc);
+create index if not exists audit_events_action_idx
+  on audit_events (action, occurred_at desc);
+
+alter table audit_events enable row level security;
+
+-- Audit history is append-only. Even privileged application SQL must not
+-- silently rewrite history; intentional break-glass maintenance requires
+-- explicitly disabling/removing this trigger in a controlled operation.
+create or replace function prevent_audit_event_mutation()
+returns trigger
+language plpgsql
+as $$
+begin
+  raise exception 'audit_events is append-only';
+end;
+$$;
+
+drop trigger if exists audit_events_append_only on audit_events;
+create trigger audit_events_append_only
+before update or delete on audit_events
+for each row execute function prevent_audit_event_mutation();
+
+revoke update, delete, truncate on audit_events from public, anon, authenticated;


### PR DESCRIPTION
## Summary

重要操作を長期追跡できるappend-only Audit Logを導入します。

Closes #33

## Changes

- `audit_events` migrationを追加
- DB triggerで既存Audit EventのUPDATE/DELETEを拒否
- RLSを有効化し、一般roleのupdate/delete/truncate権限を剥奪
- actor / role / action / target / before / after / metadataを保存
- token/secret/password/cookie/credential等のsensitive keyを再帰的にredact
- 異常に大きな文字列・深いmetadataをbounded化
- 以下を監査対象に追加
  - 日報作成・編集・公開/公開申請・承認・アーカイブ・復元・削除
  - Member/Admin role変更、Active/Inactive、Member削除
  - Notion接続/解除
  - Slack/Notion integration retry要求
- Unit testでredaction/boundsを検証

## Privacy

日報本文やOAuth tokenそのものをAudit Logへ複製しません。日報操作はID・status・version中心のmetadataに限定します。

## Migration

`supabase/migrations/202609070004_audit_events.sql`

## Target

`security/append-only-audit-log` → `main`
