### PR TITLE
security: add versioned Notion token key rotation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ SUPABASE_STORAGE_BUCKET=hanabi-log-private
 NOTION_OAUTH_CLIENT_ID=
 NOTION_OAUTH_CLIENT_SECRET=
 NOTION_TOKEN_ENCRYPTION_KEY=
+# Stable identifier for the current 32-byte encryption key. Change this when rotating keys.
+NOTION_TOKEN_ENCRYPTION_KEY_ID=primary
+# Optional old decrypt-only keys kept during rotation: key-id:base64,key-id-2:base64
+NOTION_TOKEN_DECRYPTION_KEYS=
 NOTION_API_VERSION=2026-03-11
 NOTION_DATABASE_ID=212fffe9-1997-4b7c-a631-13629baa8977
 NOTION_DATA_SOURCE_ID=aff207bb-2f47-4f19-beba-ae9556bdf442

--- a/docs/notion-token-key-rotation.md
+++ b/docs/notion-token-key-rotation.md
@@ -1,0 +1,48 @@
+# Notion OAuth token encryption key rotation
+
+Hanabi LOGはNotion OAuth tokenをAES-256-GCMで暗号化して保存する。新規ciphertextは`v2.<key-id>.<iv>.<tag>.<ciphertext>`形式を使用し、key idから復号鍵を選択する。
+
+旧`v1` ciphertextにはkey idがないため、rotation中はcurrent keyと`NOTION_TOKEN_DECRYPTION_KEYS`の全候補を順に試す。復号に成功した旧ciphertextは、通常のNotion connection読み込み時にcurrent keyへbest-effortで再暗号化される。
+
+## Variables
+
+- `NOTION_TOKEN_ENCRYPTION_KEY`: current 32-byte base64 key
+- `NOTION_TOKEN_ENCRYPTION_KEY_ID`: current keyのstable ID。`.`を含めず英数字、`_`、`-`を使用する
+- `NOTION_TOKEN_DECRYPTION_KEYS`: 旧decrypt-only keyを`key-id:base64,key-id-2:base64`形式で指定
+
+## Rotation procedure
+
+例: `2026-01`から`2027-01`へ変更する。
+
+1. 新しい32-byte random keyを生成し、secret managerへ保存する。値をIssue/PR/Slackへ貼らない。
+2. **旧keyをまだ削除しない。**
+3. Production envを次の状態にする。
+   - `NOTION_TOKEN_ENCRYPTION_KEY_ID=2027-01`
+   - `NOTION_TOKEN_ENCRYPTION_KEY=<new key>`
+   - `NOTION_TOKEN_DECRYPTION_KEYS=2026-01:<old key>`
+4. deployする。
+5. AdminでNotion connectionを読み込み、通常同期を実行する。
+6. DB上のciphertext prefixが`v2.2027-01.`へ移行したことを、token本文を表示せず確認する。
+7. 複数deployment/workerが旧設定で動いていないことを確認する。
+8. 十分なrollback window後、旧keyを`NOTION_TOKEN_DECRYPTION_KEYS`から削除する。
+
+## Legacy v1 migration
+
+既存`v1` tokenを持つ状態でcurrent keyを先に捨てると復号不能になる。初回rotationでは、旧`NOTION_TOKEN_ENCRYPTION_KEY`を必ずdecrypt-only keyとして残してから新keyへ切り替える。
+
+v1はkey idを持たないため、複数の旧keyを設定している場合は全候補を試す。v2移行後はkey idによる直接選択になる。
+
+## Rollback
+
+新key deploymentに問題がある場合でも、旧keyをdecrypt-only setから削除していなければ旧ciphertextを読める。rollback時は新keyもdecrypt-only setに残し、新deploymentが作成したv2 ciphertextを旧appが読めない状況を避けること。
+
+**注意:** v2非対応の古すぎるapplication buildへrollbackすると新ciphertextを読めない。deployment rollbackの前にciphertext format互換性を確認する。
+
+## Verification
+
+- 新しいOAuth connectionがcurrent key idのv2で保存される
+- 旧v2 tokenをprevious keyで復号できる
+- legacy v1 tokenをprevious keyで復号できる
+- context/AADが異なるtokenは復号できない
+- unknown v2 key idはfail-closedする
+- keyやtoken本文をapplication logへ出さない

--- a/src/server/env.ts
+++ b/src/server/env.ts
@@ -29,6 +29,8 @@ const schema = z.object({
   NOTION_OAUTH_CLIENT_ID: optional,
   NOTION_OAUTH_CLIENT_SECRET: optional,
   NOTION_TOKEN_ENCRYPTION_KEY: optional,
+  NOTION_TOKEN_ENCRYPTION_KEY_ID: optional,
+  NOTION_TOKEN_DECRYPTION_KEYS: optional,
   NOTION_API_VERSION: z.string().default("2026-03-11"),
   NOTION_DATABASE_ID: z.string().default("212fffe9-1997-4b7c-a631-13629baa8977"),
   NOTION_DATA_SOURCE_ID: z.string().default("aff207bb-2f47-4f19-beba-ae9556bdf442"),

--- a/src/server/integrations/notion-oauth-crypto.test.ts
+++ b/src/server/integrations/notion-oauth-crypto.test.ts
@@ -2,11 +2,15 @@ import { describe, expect, it } from "vitest";
 import {
   createNotionOAuthState,
   decryptNotionToken,
+  decryptNotionTokenWithKeyring,
   encryptNotionToken,
+  encryptNotionTokenWithKeyring,
+  notionTokenNeedsRotation,
   verifyNotionOAuthState,
 } from "@/server/integrations/notion-oauth-crypto";
 
 const key = Buffer.alloc(32, 7).toString("base64");
+const oldKey = Buffer.alloc(32, 8).toString("base64");
 
 describe("Notion OAuth cryptography", () => {
   it("round-trips an encrypted token only in the same context", () => {
@@ -18,10 +22,74 @@ describe("Notion OAuth cryptography", () => {
     expect(() => decryptNotionToken(sealed, key, "notion:bot-2:access")).toThrow();
   });
 
+  it("writes v2 ciphertext with a key id and reads it through the keyring", () => {
+    const keyring = { currentId: "2026-09", currentKey: key };
+    const sealed = encryptNotionTokenWithKeyring(
+      "secret-token",
+      keyring,
+      "notion:bot-1:access",
+    );
+    expect(sealed.startsWith("v2.2026-09.")).toBe(true);
+    expect(decryptNotionTokenWithKeyring(sealed, keyring, "notion:bot-1:access")).toBe(
+      "secret-token",
+    );
+    expect(notionTokenNeedsRotation(sealed, keyring)).toBe(false);
+  });
+
+  it("decrypts old v2 and legacy v1 ciphertext during rotation", () => {
+    const oldKeyring = { currentId: "2025", currentKey: oldKey };
+    const currentKeyring = {
+      currentId: "2026",
+      currentKey: key,
+      decryptionKeys: { "2025": oldKey },
+    };
+    const oldV2 = encryptNotionTokenWithKeyring(
+      "old-v2-token",
+      oldKeyring,
+      "notion:bot-1:access",
+    );
+    const legacy = encryptNotionToken(
+      "legacy-token",
+      oldKey,
+      "notion:bot-1:access",
+    );
+
+    expect(
+      decryptNotionTokenWithKeyring(oldV2, currentKeyring, "notion:bot-1:access"),
+    ).toBe("old-v2-token");
+    expect(
+      decryptNotionTokenWithKeyring(legacy, currentKeyring, "notion:bot-1:access"),
+    ).toBe("legacy-token");
+    expect(notionTokenNeedsRotation(oldV2, currentKeyring)).toBe(true);
+    expect(notionTokenNeedsRotation(legacy, currentKeyring)).toBe(true);
+  });
+
+  it("rejects unknown key ids instead of guessing for v2", () => {
+    const sealed = encryptNotionTokenWithKeyring(
+      "token",
+      { currentId: "old", currentKey: oldKey },
+      "context",
+    );
+    expect(() =>
+      decryptNotionTokenWithKeyring(
+        sealed,
+        { currentId: "current", currentKey: key },
+        "context",
+      ),
+    ).toThrow(/Unknown Notion token encryption key id/);
+  });
+
   it("rejects invalid encryption key sizes", () => {
     expect(() => encryptNotionToken("token", "bad", "context")).toThrow(
       /32-byte/,
     );
+    expect(() =>
+      encryptNotionTokenWithKeyring(
+        "token",
+        { currentId: "current", currentKey: "bad" },
+        "context",
+      ),
+    ).toThrow(/32-byte/);
   });
 
   it("signs state for one member and expires it", () => {

--- a/src/server/integrations/notion-oauth-crypto.ts
+++ b/src/server/integrations/notion-oauth-crypto.ts
@@ -6,9 +6,11 @@ import {
   timingSafeEqual,
 } from "node:crypto";
 
-const TOKEN_FORMAT = "v1";
+const LEGACY_TOKEN_FORMAT = "v1";
+const KEYRING_TOKEN_FORMAT = "v2";
 const IV_BYTES = 12;
 const TAG_BYTES = 16;
+const KEY_ID_PATTERN = /^[A-Za-z0-9_-]{1,32}$/;
 
 function encryptionKey(value: string): Buffer {
   const key = Buffer.from(value, "base64");
@@ -18,6 +20,28 @@ function encryptionKey(value: string): Buffer {
   return key;
 }
 
+function decryptPayload(
+  ivValue: string,
+  tagValue: string,
+  ciphertextValue: string,
+  keyValue: string,
+  context: string,
+): string {
+  const iv = Buffer.from(ivValue, "base64url");
+  const tag = Buffer.from(tagValue, "base64url");
+  if (iv.length !== IV_BYTES || tag.length !== TAG_BYTES) {
+    throw new Error("Invalid encrypted Notion token metadata");
+  }
+  const decipher = createDecipheriv("aes-256-gcm", encryptionKey(keyValue), iv);
+  decipher.setAAD(Buffer.from(context, "utf8"));
+  decipher.setAuthTag(tag);
+  return Buffer.concat([
+    decipher.update(Buffer.from(ciphertextValue, "base64url")),
+    decipher.final(),
+  ]).toString("utf8");
+}
+
+/** Legacy v1 format retained for backward compatibility and migration tests. */
 export function encryptNotionToken(
   plaintext: string,
   keyValue: string,
@@ -32,22 +56,22 @@ export function encryptNotionToken(
   ]);
   const tag = cipher.getAuthTag();
   return [
-    TOKEN_FORMAT,
+    LEGACY_TOKEN_FORMAT,
     iv.toString("base64url"),
     tag.toString("base64url"),
     ciphertext.toString("base64url"),
   ].join(".");
 }
 
+/** Legacy v1 decryptor retained so existing ciphertext remains readable. */
 export function decryptNotionToken(
   sealed: string,
   keyValue: string,
   context: string,
 ): string {
-  const [version, ivValue, tagValue, ciphertextValue, ...extra] =
-    sealed.split(".");
+  const [version, ivValue, tagValue, ciphertextValue, ...extra] = sealed.split(".");
   if (
-    version !== TOKEN_FORMAT ||
+    version !== LEGACY_TOKEN_FORMAT ||
     !ivValue ||
     !tagValue ||
     !ciphertextValue ||
@@ -55,18 +79,102 @@ export function decryptNotionToken(
   ) {
     throw new Error("Unsupported encrypted Notion token format");
   }
-  const iv = Buffer.from(ivValue, "base64url");
-  const tag = Buffer.from(tagValue, "base64url");
-  if (iv.length !== IV_BYTES || tag.length !== TAG_BYTES) {
-    throw new Error("Invalid encrypted Notion token metadata");
+  return decryptPayload(ivValue, tagValue, ciphertextValue, keyValue, context);
+}
+
+export interface NotionTokenKeyring {
+  currentId: string;
+  currentKey: string;
+  decryptionKeys?: Record<string, string>;
+}
+
+function validateKeyring(keyring: NotionTokenKeyring): void {
+  if (!KEY_ID_PATTERN.test(keyring.currentId)) {
+    throw new Error("Invalid Notion token encryption key id");
   }
-  const decipher = createDecipheriv("aes-256-gcm", encryptionKey(keyValue), iv);
-  decipher.setAAD(Buffer.from(context, "utf8"));
-  decipher.setAuthTag(tag);
-  return Buffer.concat([
-    decipher.update(Buffer.from(ciphertextValue, "base64url")),
-    decipher.final(),
-  ]).toString("utf8");
+  encryptionKey(keyring.currentKey);
+  for (const [id, key] of Object.entries(keyring.decryptionKeys ?? {})) {
+    if (!KEY_ID_PATTERN.test(id)) throw new Error("Invalid Notion token decryption key id");
+    encryptionKey(key);
+  }
+}
+
+export function encryptNotionTokenWithKeyring(
+  plaintext: string,
+  keyring: NotionTokenKeyring,
+  context: string,
+): string {
+  validateKeyring(keyring);
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv("aes-256-gcm", encryptionKey(keyring.currentKey), iv);
+  cipher.setAAD(Buffer.from(context, "utf8"));
+  const ciphertext = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return [
+    KEYRING_TOKEN_FORMAT,
+    keyring.currentId,
+    iv.toString("base64url"),
+    tag.toString("base64url"),
+    ciphertext.toString("base64url"),
+  ].join(".");
+}
+
+export function decryptNotionTokenWithKeyring(
+  sealed: string,
+  keyring: NotionTokenKeyring,
+  context: string,
+): string {
+  validateKeyring(keyring);
+  const parts = sealed.split(".");
+
+  if (parts[0] === KEYRING_TOKEN_FORMAT) {
+    const [version, keyId, ivValue, tagValue, ciphertextValue, ...extra] = parts;
+    if (
+      version !== KEYRING_TOKEN_FORMAT ||
+      !keyId ||
+      !ivValue ||
+      !tagValue ||
+      !ciphertextValue ||
+      extra.length > 0
+    ) {
+      throw new Error("Unsupported encrypted Notion token format");
+    }
+    const keyValue =
+      keyId === keyring.currentId
+        ? keyring.currentKey
+        : keyring.decryptionKeys?.[keyId];
+    if (!keyValue) throw new Error(`Unknown Notion token encryption key id: ${keyId}`);
+    return decryptPayload(ivValue, tagValue, ciphertextValue, keyValue, context);
+  }
+
+  if (parts[0] === LEGACY_TOKEN_FORMAT) {
+    const candidates = [
+      keyring.currentKey,
+      ...Object.values(keyring.decryptionKeys ?? {}),
+    ];
+    const uniqueCandidates = [...new Set(candidates)];
+    for (const candidate of uniqueCandidates) {
+      try {
+        return decryptNotionToken(sealed, candidate, context);
+      } catch {
+        // Legacy v1 has no key id, so try every configured decryption key.
+      }
+    }
+    throw new Error("Unable to decrypt legacy Notion token with configured keys");
+  }
+
+  throw new Error("Unsupported encrypted Notion token format");
+}
+
+export function notionTokenNeedsRotation(
+  sealed: string,
+  keyring: NotionTokenKeyring,
+): boolean {
+  const [version, keyId] = sealed.split(".");
+  return version !== KEYRING_TOKEN_FORMAT || keyId !== keyring.currentId;
 }
 
 interface OAuthStatePayload {

--- a/src/server/integrations/notion-oauth-store.ts
+++ b/src/server/integrations/notion-oauth-store.ts
@@ -3,8 +3,10 @@ import { getDatabase } from "@/server/db/client";
 import { env } from "@/server/env";
 import { AppError } from "@/server/errors";
 import {
-  decryptNotionToken,
-  encryptNotionToken,
+  decryptNotionTokenWithKeyring,
+  encryptNotionTokenWithKeyring,
+  notionTokenNeedsRotation,
+  type NotionTokenKeyring,
 } from "@/server/integrations/notion-oauth-crypto";
 
 interface NotionOAuthConnectionRow {
@@ -57,7 +59,7 @@ export interface SaveNotionOAuthConnectionInput {
   connectedByMemberId?: string | null;
 }
 
-function key(): string {
+function currentKey(): string {
   if (!env.NOTION_TOKEN_ENCRYPTION_KEY) {
     throw new AppError(
       "NOTION_ENCRYPTION_NOT_CONFIGURED",
@@ -68,6 +70,32 @@ function key(): string {
   return env.NOTION_TOKEN_ENCRYPTION_KEY;
 }
 
+export function parseNotionTokenDecryptionKeys(value?: string): Record<string, string> {
+  if (!value) return {};
+  const result: Record<string, string> = {};
+  for (const rawEntry of value.split(",")) {
+    const entry = rawEntry.trim();
+    if (!entry) continue;
+    const separator = entry.indexOf(":");
+    if (separator <= 0 || separator === entry.length - 1) {
+      throw new Error("NOTION_TOKEN_DECRYPTION_KEYS must use key-id:base64 entries");
+    }
+    const id = entry.slice(0, separator).trim();
+    const key = entry.slice(separator + 1).trim();
+    if (result[id]) throw new Error(`Duplicate Notion token decryption key id: ${id}`);
+    result[id] = key;
+  }
+  return result;
+}
+
+function keyring(): NotionTokenKeyring {
+  return {
+    currentId: env.NOTION_TOKEN_ENCRYPTION_KEY_ID ?? "primary",
+    currentKey: currentKey(),
+    decryptionKeys: parseNotionTokenDecryptionKeys(env.NOTION_TOKEN_DECRYPTION_KEYS),
+  };
+}
+
 function context(botId: string, token: "access" | "refresh"): string {
   return `notion:${botId}:${token}`;
 }
@@ -76,8 +104,10 @@ function iso(value: Date | string): string {
   return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
 }
 
-function mapConnection(row: NotionOAuthConnectionRow): NotionOAuthConnection {
-  const encryptionKey = key();
+function mapConnection(
+  row: NotionOAuthConnectionRow,
+  tokenKeyring: NotionTokenKeyring,
+): NotionOAuthConnection {
   return {
     workspaceId: row.workspace_id,
     workspaceName: row.workspace_name,
@@ -85,15 +115,15 @@ function mapConnection(row: NotionOAuthConnectionRow): NotionOAuthConnection {
     botId: row.bot_id,
     ownerUserId: row.owner_user_id,
     ownerUserName: row.owner_user_name,
-    accessToken: decryptNotionToken(
+    accessToken: decryptNotionTokenWithKeyring(
       row.access_token_ciphertext,
-      encryptionKey,
+      tokenKeyring,
       context(row.bot_id, "access"),
     ),
     refreshToken: row.refresh_token_ciphertext
-      ? decryptNotionToken(
+      ? decryptNotionTokenWithKeyring(
           row.refresh_token_ciphertext,
-          encryptionKey,
+          tokenKeyring,
           context(row.bot_id, "refresh"),
         )
       : null,
@@ -101,6 +131,48 @@ function mapConnection(row: NotionOAuthConnectionRow): NotionOAuthConnection {
     connectedAt: iso(row.connected_at),
     updatedAt: iso(row.updated_at),
   };
+}
+
+async function rotateConnectionCiphertextIfNeeded(
+  row: NotionOAuthConnectionRow,
+  connection: NotionOAuthConnection,
+  tokenKeyring: NotionTokenKeyring,
+): Promise<void> {
+  const accessNeedsRotation = notionTokenNeedsRotation(
+    row.access_token_ciphertext,
+    tokenKeyring,
+  );
+  const refreshNeedsRotation = Boolean(
+    row.refresh_token_ciphertext &&
+      notionTokenNeedsRotation(row.refresh_token_ciphertext, tokenKeyring),
+  );
+  if (!accessNeedsRotation && !refreshNeedsRotation) return;
+
+  const accessCiphertext = encryptNotionTokenWithKeyring(
+    connection.accessToken,
+    tokenKeyring,
+    context(row.bot_id, "access"),
+  );
+  const refreshCiphertext = connection.refreshToken
+    ? encryptNotionTokenWithKeyring(
+        connection.refreshToken,
+        tokenKeyring,
+        context(row.bot_id, "refresh"),
+      )
+    : null;
+
+  try {
+    await getDatabase()`update notion_oauth_connections
+      set access_token_ciphertext = ${accessCiphertext},
+          refresh_token_ciphertext = ${refreshCiphertext},
+          updated_at = now()
+      where id = 'primary'
+        and access_token_ciphertext = ${row.access_token_ciphertext}`;
+  } catch (error) {
+    // Decryption succeeded, so a transient rotation write must not break Notion use.
+    // Keep previous keys configured until every stored token has migrated.
+    console.error("Notion OAuth token re-encryption failed", { error });
+  }
 }
 
 export async function getNotionOAuthConnection(): Promise<NotionOAuthConnection | null> {
@@ -113,7 +185,12 @@ export async function getNotionOAuthConnection(): Promise<NotionOAuthConnection 
     from notion_oauth_connections
     where id = 'primary'
   `;
-  return rows[0] ? mapConnection(rows[0]) : null;
+  const row = rows[0];
+  if (!row) return null;
+  const tokenKeyring = keyring();
+  const connection = mapConnection(row, tokenKeyring);
+  await rotateConnectionCiphertextIfNeeded(row, connection, tokenKeyring);
+  return connection;
 }
 
 export async function getNotionOAuthConnectionSummary(): Promise<NotionOAuthConnectionSummary> {
@@ -151,16 +228,16 @@ export async function saveNotionOAuthConnection(
   input: SaveNotionOAuthConnectionInput,
 ): Promise<void> {
   const sql = getDatabase();
-  const encryptionKey = key();
-  const accessCiphertext = encryptNotionToken(
+  const tokenKeyring = keyring();
+  const accessCiphertext = encryptNotionTokenWithKeyring(
     input.accessToken,
-    encryptionKey,
+    tokenKeyring,
     context(input.botId, "access"),
   );
   const refreshCiphertext = input.refreshToken
-    ? encryptNotionToken(
+    ? encryptNotionTokenWithKeyring(
         input.refreshToken,
-        encryptionKey,
+        tokenKeyring,
         context(input.botId, "refresh"),
       )
     : null;


### PR DESCRIPTION
## Summary

Notion OAuth token暗号鍵をサービス停止せず安全にrotationできるkeyringを導入します。

Closes #38

## Changes

- 新規ciphertextを`v2.<key-id>.<iv>.<tag>.<ciphertext>`形式へ変更
- current key +複数のdecrypt-only旧鍵を扱うkeyringを追加
- legacy `v1` ciphertextを後方互換で復号
- v1はkey idがないためrotation中の旧key候補を安全に試行
- old v2はkey idで直接復号鍵を選択
- Notion connection読込時に旧ciphertextをcurrent keyへbest-effort再暗号化
- unknown v2 key idはfail-closed
- rotation / rollback手順をdocs化
- key rotation Unit testを追加

## New environment variables

- `NOTION_TOKEN_ENCRYPTION_KEY_ID`（default: `primary`）
- `NOTION_TOKEN_DECRYPTION_KEYS`（optional `key-id:base64,...`）

既存の`NOTION_TOKEN_ENCRYPTION_KEY`はcurrent keyとして維持します。

## Target

`security/notion-key-rotation` → `main`
