### PR TITLE
db: add bounded operational data retention

### DIFF
--- a/docs/data-retention.md
+++ b/docs/data-retention.md
@@ -1,0 +1,42 @@
+# Data Retention Policy
+
+Hanabi LOGでは、長期的な知識記録と一時的な運用データを分離する。日報・将来のRevision・Audit Log等の正本/履歴データを、運用テーブルのcleanupと同じルールで削除してはいけない。
+
+## Automated retention
+
+| Data | Retention | Reason |
+| --- | ---: | --- |
+| `idempotency_keys` | 60 days | retry windowを十分に超えた重複防止response cache |
+| delivered `outbox_jobs` | 90 days after completion | 配信調査期間を残しつつ成功jobの無限増加を防ぐ |
+| dead `outbox_jobs` | 365 days | 長期障害調査・傾向分析のため成功jobより長く保持 |
+| processed `slack_incoming_reports` | 180 days | Slack retry重複防止と調査期間 |
+| processed `slack_report_reactions` | 180 days | reaction retry/tombstoneの調査期間 |
+
+以下はこのcleanup対象外。
+
+- members
+- reports
+- related links
+- attachments
+- report likes / contribution history（別途product policyが決まるまで）
+- Audit Log
+- Report Revision
+- 未処理/処理中/再試行待ちのOutbox
+- 未処理Slack event/reaction
+
+## Execution
+
+既存のintegration Cronの最後でcleanupを実行する。各categoryは1回最大500件を削除し、巨大な単発DELETEや長時間lockを避ける。蓄積が多い場合は複数回のCronで徐々に追いつく。
+
+## Safety rules
+
+- cleanupは冪等であること。
+- `pending` / `processing` / retry対象データを削除しない。
+- dead-letterのretentionを短くしない。
+- retention期間を短縮する変更はPRで明示する。
+- retention対象追加時は、障害解析・法務/プライバシー・データ可搬性への影響を確認する。
+- 大規模削除前にはbackup/restore手順が利用可能であることを確認する。
+
+## Audit and Revision
+
+Audit LogとReport Revisionは長期履歴として扱い、この自動cleanupから除外する。将来容量上限が問題になった場合も、削除より先にcold archive / portable archiveへの退避を検討する。

--- a/src/app/api/cron/integrations/route.ts
+++ b/src/app/api/cron/integrations/route.ts
@@ -7,6 +7,7 @@ import { processPendingJobs } from "@/server/integrations/outbox";
 import { processIncomingSlackReports } from "@/server/integrations/slack-incoming-store";
 
 import { processLikeNotifications } from "@/server/integrations/like-notifications";
+import { cleanupOperationalData } from "@/server/maintenance/retention";
 
 function authorized(request: Request): boolean {
   if (isDemoMode && !env.CRON_SECRET) return true;
@@ -26,7 +27,8 @@ export async function POST(request: Request): Promise<Response> {
     await processIncomingSlackReports();
     await processLikeNotifications();
     const result = await processPendingJobs();
-    return Response.json(result, { headers: { "Cache-Control": "no-store" } });
+    const cleanup = await cleanupOperationalData();
+    return Response.json({ ...result, cleanup }, { headers: { "Cache-Control": "no-store" } });
   });
 }
 

--- a/src/server/maintenance/retention.test.ts
+++ b/src/server/maintenance/retention.test.ts
@@ -1,0 +1,34 @@
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+vi.mock("server-only", () => ({}));
+vi.mock("@/server/db/client", () => ({ getDatabase: vi.fn() }));
+vi.mock("@/server/env", () => ({ env: { NODE_ENV: "test" }, isDemoMode: false }));
+
+let cleanupOperationalData: typeof import("./retention").cleanupOperationalData;
+let RETENTION_DAYS: typeof import("./retention").RETENTION_DAYS;
+
+beforeAll(async () => {
+  ({ cleanupOperationalData, RETENTION_DAYS } = await import("./retention"));
+});
+
+describe("operational retention", () => {
+  it("keeps conservative retention windows", () => {
+    expect(RETENTION_DAYS).toEqual({
+      idempotencyKeys: 60,
+      deliveredOutbox: 90,
+      deadOutbox: 365,
+      processedSlackEvents: 180,
+      processedSlackReactions: 180,
+    });
+  });
+
+  it("does not touch a database from unit-test runtime", async () => {
+    await expect(cleanupOperationalData()).resolves.toEqual({
+      idempotencyKeys: 0,
+      deliveredOutbox: 0,
+      deadOutbox: 0,
+      processedSlackEvents: 0,
+      processedSlackReactions: 0,
+    });
+  });
+});

--- a/src/server/maintenance/retention.ts
+++ b/src/server/maintenance/retention.ts
@@ -1,0 +1,90 @@
+import "server-only";
+import { getDatabase } from "@/server/db/client";
+import { env, isDemoMode } from "@/server/env";
+
+export const RETENTION_DAYS = {
+  idempotencyKeys: 60,
+  deliveredOutbox: 90,
+  deadOutbox: 365,
+  processedSlackEvents: 180,
+  processedSlackReactions: 180,
+} as const;
+
+export interface RetentionCleanupSummary {
+  idempotencyKeys: number;
+  deliveredOutbox: number;
+  deadOutbox: number;
+  processedSlackEvents: number;
+  processedSlackReactions: number;
+}
+
+function emptySummary(): RetentionCleanupSummary {
+  return {
+    idempotencyKeys: 0,
+    deliveredOutbox: 0,
+    deadOutbox: 0,
+    processedSlackEvents: 0,
+    processedSlackReactions: 0,
+  };
+}
+
+export async function cleanupOperationalData(
+  batchSize = 500,
+): Promise<RetentionCleanupSummary> {
+  if (env.NODE_ENV === "test" || isDemoMode) return emptySummary();
+  const limit = Math.min(2_000, Math.max(1, Math.floor(batchSize)));
+  const sql = getDatabase();
+
+  const idempotencyKeys = await sql`delete from idempotency_keys
+    where ctid in (
+      select ctid from idempotency_keys
+      where created_at < now() - interval '60 days'
+      order by created_at
+      limit ${limit}
+    ) returning 1`;
+
+  const deliveredOutbox = await sql`delete from outbox_jobs
+    where ctid in (
+      select ctid from outbox_jobs
+      where status = 'delivered'
+        and completed_at is not null
+        and completed_at < now() - interval '90 days'
+      order by completed_at
+      limit ${limit}
+    ) returning 1`;
+
+  const deadOutbox = await sql`delete from outbox_jobs
+    where ctid in (
+      select ctid from outbox_jobs
+      where status = 'dead'
+        and created_at < now() - interval '365 days'
+      order by created_at
+      limit ${limit}
+    ) returning 1`;
+
+  const processedSlackEvents = await sql`delete from slack_incoming_reports
+    where ctid in (
+      select ctid from slack_incoming_reports
+      where processed_at is not null
+        and created_at < now() - interval '180 days'
+      order by created_at
+      limit ${limit}
+    ) returning 1`;
+
+  const processedSlackReactions = await sql`delete from slack_report_reactions
+    where ctid in (
+      select ctid from slack_report_reactions
+      where processed_at is not null
+        and to_timestamp(event_ts::double precision) < now() - interval '180 days'
+      order by event_ts
+      limit ${limit}
+    ) returning 1`;
+
+  return {
+    idempotencyKeys: idempotencyKeys.length,
+    deliveredOutbox: deliveredOutbox.length,
+    deadOutbox: deadOutbox.length,
+    processedSlackEvents: processedSlackEvents.length,
+    processedSlackReactions: processedSlackReactions.length,
+  };
+}

--- a/supabase/migrations/202609070005_operational_retention_indexes.sql
+++ b/supabase/migrations/202609070005_operational_retention_indexes.sql
@@ -1,0 +1,20 @@
+-- Indexes used by bounded retention cleanup. Long-lived domain records such as
+-- reports are intentionally excluded from automated retention.
+create index if not exists idempotency_keys_created_at_idx
+  on idempotency_keys (created_at);
+
+create index if not exists outbox_jobs_completed_retention_idx
+  on outbox_jobs (completed_at)
+  where status = 'delivered' and completed_at is not null;
+
+create index if not exists outbox_jobs_dead_retention_idx
+  on outbox_jobs (created_at)
+  where status = 'dead';
+
+create index if not exists slack_incoming_reports_processed_retention_idx
+  on slack_incoming_reports (created_at)
+  where processed_at is not null;
+
+create index if not exists slack_report_reactions_processed_retention_idx
+  on slack_report_reactions (event_ts)
+  where processed_at is not null;


### PR DESCRIPTION
## Summary

長期運用で一時的な運用テーブルが無制限に肥大化しないよう、明示的なretention policyとbounded cleanupを追加します。

Closes #39

## Retention

- idempotency keys: 60 days
- delivered outbox: 90 days
- dead outbox: 365 days
- processed Slack incoming events: 180 days
- processed Slack reactions: 180 days

日報・Audit・Revision等の長期記録はcleanup対象外です。

## Changes

- retention対象のpartial/indexを追加
- integration Cron終了時にcleanupを実行
- categoryごとに1回最大500件だけ削除
- pending/processing/retry待ちデータは削除しない
- policyを`docs/data-retention.md`へ明文化
- test runtimeではDB cleanupを行わないことをテスト

## Migration

`supabase/migrations/202609070005_operational_retention_indexes.sql`

## Target

`db/operational-retention` → `main`
