### PR TITLE
security: enforce nonce-based Content Security Policy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,8 @@
 APP_BASE_URL=http://localhost:3000
 AUTH_SECRET=
 DEMO_MODE=true
+# Optional staged CSP rollout. true sends Content-Security-Policy-Report-Only instead of enforcing it.
+CSP_REPORT_ONLY=false
 
 # Slack Sign in with Slack + Bot
 SLACK_CLIENT_ID=

--- a/docs/content-security-policy.md
+++ b/docs/content-security-policy.md
@@ -1,0 +1,67 @@
+# Content Security Policy
+
+Hanabi LOGはNext.js App Routerのnonce対応を利用し、ページリクエストごとに新しいnonceを生成してCSPを適用します。
+
+## Policy
+
+Productionでは概ね次の制約を適用します。
+
+- scripts: `self` + request nonce + `strict-dynamic`
+- `unsafe-eval`: productionでは禁止
+- inline script attributes: 禁止
+- styles: frameworkのnonce付きstyleを許可
+- style attributes: 現行UI互換のため許可（scriptとは分離）
+- images: self / blob / data / Supabase / Slack avatar / Gravatar
+- browser connections: self / Supabase HTTPS + WebSocket
+- workers: self / blob（Service Workerを含む）
+- objects / frames: 禁止
+- base URI: self
+- form actions: self
+- frame ancestors: none
+- productionではHTTP resourceをupgrade
+
+Slack / Notion APIへのserver-side通信はブラウザCSPの`connect-src`対象ではありません。Private Storageへのsigned upload/readはブラウザからSupabaseへ通信するため許可します。
+
+## Nonce flow
+
+1. `src/proxy.ts`がページrequestごとに暗号学的にランダムなnonceを生成
+2. request headerへ`x-nonce`とCSPを追加
+3. Next.jsがCSP内のnonceを読み、framework script/styleへnonceを付与
+4. 同じCSPをresponse headerへ付与
+
+API、Next.js static assets、image optimizer、Service Worker、offline fallbackはProxyのpage CSP処理対象から除外します。
+
+## Report-Only rollout
+
+新しいdirectiveや外部originを追加する場合は、いきなりproduction enforcementを緩めるのではなく段階的に確認します。
+
+1. Previewまたはproductionで一時的に`CSP_REPORT_ONLY=true`
+2. Chromium / WebKitで主要フローを確認
+   - login
+   - report list/detail
+   - create/edit/publish
+   - image signed upload/read
+   - PWA install / Service Worker
+   - admin
+3. Browser console / response headersで違反を確認
+4. 必要なoriginだけをpolicyへ追加
+5. `CSP_REPORT_ONLY=false`へ戻してenforce
+6. 同じ主要フローを再確認
+
+Report-Onlyを常設の逃げ道として使わず、検証期間だけ利用します。
+
+## Development
+
+React / Next.js development debuggingのため、developmentだけ`unsafe-eval`を許可します。Production policyへは含めません。
+
+## Adding a new browser integration
+
+新しい外部サービスをbrowserから直接利用する場合、CSPを`*`へ広げないでください。
+
+1. 必要なresource typeを特定する（connect/img/script等）
+2. 最小originを追加する
+3. Report-Onlyで検証する
+4. testを更新する
+5. enforcementへ移行する
+
+Server-only integrationはCSP allowlistへ追加する必要がありません。

--- a/src/lib/security/csp.test.ts
+++ b/src/lib/security/csp.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import {
+  CSP_HEADER,
+  CSP_REPORT_ONLY_HEADER,
+  createCspHeader,
+  cspHeaderName,
+} from "@/lib/security/csp";
+
+describe("Content Security Policy", () => {
+  it("uses a nonce and does not allow unsafe-eval in production", () => {
+    const header = createCspHeader("abc123", false);
+    expect(header).toContain("script-src 'self' 'nonce-abc123' 'strict-dynamic'");
+    expect(header).not.toContain("'unsafe-eval'");
+    expect(header).toContain("object-src 'none'");
+    expect(header).toContain("frame-ancestors 'none'");
+    expect(header).toContain("upgrade-insecure-requests");
+  });
+
+  it("allows React development eval only in development", () => {
+    const header = createCspHeader("devnonce", true);
+    expect(header).toContain("'unsafe-eval'");
+    expect(header).not.toContain("upgrade-insecure-requests");
+  });
+
+  it("switches between report-only and enforcement headers", () => {
+    expect(cspHeaderName(false)).toBe(CSP_HEADER);
+    expect(cspHeaderName(true)).toBe(CSP_REPORT_ONLY_HEADER);
+  });
+});

--- a/src/lib/security/csp.ts
+++ b/src/lib/security/csp.ts
@@ -1,0 +1,29 @@
+export const CSP_HEADER = "Content-Security-Policy";
+export const CSP_REPORT_ONLY_HEADER = "Content-Security-Policy-Report-Only";
+
+export function createCspHeader(nonce: string, isDevelopment: boolean): string {
+  const directives = [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDevelopment ? " 'unsafe-eval'" : ""}`,
+    "script-src-attr 'none'",
+    `style-src 'self' 'nonce-${nonce}'`,
+    "style-src-attr 'unsafe-inline'",
+    "img-src 'self' blob: data: https://*.supabase.co https://avatars.slack-edge.com https://secure.gravatar.com",
+    "font-src 'self' data:",
+    "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+    "worker-src 'self' blob:",
+    "manifest-src 'self'",
+    "media-src 'self' blob:",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "frame-src 'none'",
+  ];
+  if (!isDevelopment) directives.push("upgrade-insecure-requests");
+  return directives.map((directive) => `${directive};`).join(" ");
+}
+
+export function cspHeaderName(reportOnly: boolean): string {
+  return reportOnly ? CSP_REPORT_ONLY_HEADER : CSP_HEADER;
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,33 +1,69 @@
 import { getToken } from "next-auth/jwt";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import { createCspHeader, cspHeaderName } from "@/lib/security/csp";
+
+const PROTECTED_PATHS = ["/reports", "/new", "/archive", "/me", "/admin"];
 
 function localDemoMode(): boolean {
+  if (process.env.NODE_ENV === "production") return false;
   return (
     process.env.DEMO_MODE === "true" ||
-    (process.env.NODE_ENV !== "production" &&
-      !process.env.DEMO_MODE &&
-      !process.env.DATABASE_URL)
+    (!process.env.DEMO_MODE && !process.env.DATABASE_URL)
   );
 }
 
+function requiresAuthentication(pathname: string): boolean {
+  return (
+    pathname === "/" ||
+    PROTECTED_PATHS.some(
+      (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+    )
+  );
+}
+
+function cspContext(request: NextRequest) {
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const value = createCspHeader(nonce, process.env.NODE_ENV === "development");
+  const reportOnly = process.env.CSP_REPORT_ONLY === "true";
+  const name = cspHeaderName(reportOnly);
+  const headers = new Headers(request.headers);
+  headers.set("x-nonce", nonce);
+  headers.set(name, value);
+  return { name, value, headers };
+}
+
+function nextWithCsp(request: NextRequest): NextResponse {
+  const csp = cspContext(request);
+  const response = NextResponse.next({ request: { headers: csp.headers } });
+  response.headers.set(csp.name, csp.value);
+  return response;
+}
+
 export async function proxy(request: NextRequest) {
-  if (localDemoMode()) return NextResponse.next();
+  if (!requiresAuthentication(request.nextUrl.pathname) || localDemoMode()) {
+    return nextWithCsp(request);
+  }
 
   const token = await getToken({
     req: request,
     secret: process.env.AUTH_SECRET,
   });
-  if (token) return NextResponse.next();
+  if (token) return nextWithCsp(request);
 
   const loginUrl = new URL("/login", request.url);
   loginUrl.searchParams.set(
     "callbackUrl",
     `${request.nextUrl.pathname}${request.nextUrl.search}`,
   );
-  return NextResponse.redirect(loginUrl);
+  const csp = cspContext(request);
+  const response = NextResponse.redirect(loginUrl);
+  response.headers.set(csp.name, csp.value);
+  return response;
 }
 
 export const config = {
-  matcher: ["/", "/reports/:path*", "/new/:path*", "/archive/:path*", "/me/:path*", "/admin/:path*"],
+  matcher: [
+    "/((?!api|_next/static|_next/image|favicon.ico|sw.js|offline.html).*)",
+  ],
 };


### PR DESCRIPTION
## Summary

Next.js App Router向けにrequest nonceを使うstrict CSPを導入します。

Closes #36

## Changes

- page requestごとにfresh nonceを生成
- Next.js request/responseへCSPを設定
- productionの`script-src`から`unsafe-eval`を排除
- `strict-dynamic` + nonceを使用
- Supabase signed upload/readに必要なbrowser originだけを許可
- object/frameをdeny、frame ancestorsをdeny
- `CSP_REPORT_ONLY=true`で段階検証可能
- CSP policy builderのUnit testを追加
- rollout / browser verification / allowlist追加手順をdocs化
- ProxyのDemo Mode判定をproduction fail-closedへ統一

## Browser compatibility

Next.jsのnonce機構によりframework script/styleへ同じnonceを適用します。Chromium/WebKitは既存CI E2Eで確認します。

## Target

`security/strict-csp` → `main`
