### PR TITLE
feat: optimize uploaded images before upload

### DIFF
--- a/e2e/image-optimization-webkit.spec.ts
+++ b/e2e/image-optimization-webkit.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+import { openPage } from "./navigation";
+
+test("WebKitで画像最適化からDemo Signed Uploadまで完了する", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "webkit", "Safari互換経路をWebKitで検証する");
+
+  await openPage(page, "/reports/new");
+  const base64 = await page.evaluate(() => {
+    const canvas = document.createElement("canvas");
+    canvas.width = 96;
+    canvas.height = 64;
+    const context = canvas.getContext("2d")!;
+    context.fillStyle = "#ffffff";
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.fillStyle = "#222222";
+    context.fillRect(8, 8, 80, 48);
+    const encoded = canvas.toDataURL("image/png").split(",")[1];
+    canvas.width = canvas.height = 0;
+    return encoded;
+  });
+
+  await page.locator('input[type="file"]').setInputFiles({
+    name: "webkit-fixture.png",
+    mimeType: "image/png",
+    buffer: Buffer.from(base64, "base64"),
+  });
+
+  await expect(page.locator("#image-optimization-status")).toContainText("画像を最適化しました", { timeout: 30_000 });
+  await expect(page.locator(".attachment-item")).toHaveCount(1);
+  await expect(page.locator("#attachments-error")).toHaveCount(0);
+  await expect(page.locator(".attachment-item small")).toContainText("MiB");
+});

--- a/e2e/image-optimization.spec.ts
+++ b/e2e/image-optimization.spec.ts
@@ -1,0 +1,346 @@
+import { createHash } from "node:crypto";
+import { expect, test, type Page } from "@playwright/test";
+import { openPage } from "./navigation";
+
+const MiB = 1024 * 1024;
+type ImageFile = { name: string; mimeType: string; buffer: Buffer };
+type UploadMetadata = { filename: string; mimeType: string; sizeBytes: number };
+type UploadedBytes = { mimeType: string; bytes: Buffer };
+
+test.setTimeout(150_000);
+// Large fixtures are generated one at a time in each browser, without binary assets or dependencies.
+test.describe.configure({ mode: "default" });
+
+async function canvasFile(page: Page, kind: "photo" | "alpha" | "quadrants" | "noise"): Promise<ImageFile> {
+  const result = await page.evaluate((fixtureKind) => {
+    const canvas = document.createElement("canvas");
+    // Keep fixture memory bounded on WebKit and mobile while still producing
+    // files above the server's 5 MiB limit.
+    canvas.width = fixtureKind === "quadrants" ? 120 : fixtureKind === "noise" ? 640 : fixtureKind === "alpha" ? 2400 : 2600;
+    canvas.height = fixtureKind === "quadrants" ? 80 : fixtureKind === "noise" ? 480 : fixtureKind === "alpha" ? 1800 : 1900;
+    const context = canvas.getContext("2d")!;
+    if (fixtureKind === "quadrants") {
+      ["#ff0000", "#0000ff", "#00ff00", "#ffffff"].forEach((color, index) => {
+        context.fillStyle = color;
+        context.fillRect((index % 2) * 60, Math.floor(index / 2) * 40, 60, 40);
+      });
+    } else {
+      const pixels = context.createImageData(canvas.width, canvas.height);
+      let random = 0x12345678;
+      for (let offset = 0; offset < pixels.data.length; offset += 4) {
+        random ^= random << 13;
+        random ^= random >>> 17;
+        random ^= random << 5;
+        const gray = random & 255;
+        pixels.data[offset] = gray;
+        pixels.data[offset + 1] = fixtureKind === "alpha" ? gray : (random >>> 8) & 255;
+        pixels.data[offset + 2] = fixtureKind === "alpha" ? gray : (random >>> 16) & 255;
+        pixels.data[offset + 3] = fixtureKind === "alpha" && (offset / 4) % canvas.width < canvas.width / 8 ? 0 : 255;
+      }
+      context.putImageData(pixels, 0, 0);
+    }
+    const mimeType = fixtureKind === "alpha" ? "image/png" : "image/jpeg";
+    const base64 = canvas.toDataURL(mimeType, 1).split(",")[1];
+    canvas.width = canvas.height = 0;
+    return { base64, mimeType };
+  }, kind);
+  return {
+    name: `${kind}.${result.mimeType === "image/png" ? "png" : "jpg"}`,
+    mimeType: result.mimeType,
+    buffer: Buffer.from(result.base64, "base64"),
+  };
+}
+
+async function captureUploads(page: Page) {
+  const metadata: UploadMetadata[] = [];
+  const uploads: UploadedBytes[] = [];
+  await page.route("**/api/uploads*", async (route) => {
+    const request = route.request();
+    if (request.method() === "POST") metadata.push(request.postDataJSON() as UploadMetadata);
+    if (request.method() === "PUT") {
+      uploads.push({ mimeType: request.headers()["content-type"], bytes: request.postDataBuffer()! });
+    }
+    await route.continue();
+  });
+  return { metadata, uploads };
+}
+
+async function inspectImage(page: Page, upload: UploadedBytes) {
+  return page.evaluate(async ({ base64, mimeType }) => {
+    const image = new Image();
+    image.src = `data:${mimeType};base64,${base64}`;
+    await image.decode();
+    const canvas = document.createElement("canvas");
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalHeight;
+    const context = canvas.getContext("2d")!;
+    context.drawImage(image, 0, 0);
+    const samples = [[0.05, 0.5], [0.25, 0.25], [0.75, 0.25], [0.25, 0.75], [0.75, 0.75]].map(([x, y]) =>
+      Array.from(context.getImageData(Math.floor(canvas.width * x), Math.floor(canvas.height * y), 1, 1).data),
+    );
+    const result = { width: canvas.width, height: canvas.height, samples };
+    canvas.width = canvas.height = 0;
+    return result;
+  }, { base64: upload.bytes.toString("base64"), mimeType: upload.mimeType });
+}
+
+function assertUploadMatches(metadata: UploadMetadata, upload: UploadedBytes) {
+  expect(upload.bytes.length).toBe(metadata.sizeBytes);
+  expect(upload.mimeType).toBe(metadata.mimeType);
+  expect(metadata.sizeBytes).toBeGreaterThan(0);
+  expect(metadata.sizeBytes).toBeLessThanOrEqual(5 * MiB);
+  const extension = metadata.filename.split(".").at(-1);
+  if (metadata.mimeType === "image/jpeg") {
+    expect(extension).toMatch(/^jpe?g$/);
+    expect(upload.bytes.subarray(0, 2).toString("hex")).toBe("ffd8");
+  } else if (metadata.mimeType === "image/png") {
+    expect(extension).toBe("png");
+    expect(upload.bytes.subarray(0, 8).toString("hex")).toBe("89504e470d0a1a0a");
+  } else {
+    expect(metadata.mimeType).toBe("image/webp");
+    expect(extension).toBe("webp");
+    expect(upload.bytes.subarray(0, 4).toString()).toBe("RIFF");
+    expect(upload.bytes.subarray(8, 12).toString()).toBe("WEBP");
+  }
+}
+
+async function fillReport(page: Page, title: string) {
+  await page.getByLabel("タイトル任意").fill(title);
+  await page.getByLabel("活動領域必須").selectOption({ label: "ロボット" });
+  await page.getByLabel("内容カテゴリ必須").selectOption({ label: "進捗" });
+  await page.getByLabel("今日やったこと必須").fill("ブラウザで画像を最適化して日報に添付した。");
+}
+
+test("大きいJPEGと透過PNGを最適化し、実データを保存して日報で表示できる", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name !== "desktop", "大きな実画像の経路はChromiumで検証する");
+  await openPage(page, "/reports/new");
+  const photo = await canvasFile(page, "photo");
+  const alpha = await canvasFile(page, "alpha");
+  const files = [photo, alpha];
+  const originalTotal = files.reduce((sum, file) => sum + file.buffer.length, 0);
+  expect(photo.buffer.length).toBeGreaterThan(5 * MiB);
+  expect(alpha.buffer.length).toBeGreaterThan(5 * MiB);
+  expect(originalTotal).toBeGreaterThan(10 * MiB);
+  const originalHashes = files.map((file) => createHash("sha256").update(file.buffer).digest("hex"));
+  const captured = await captureUploads(page);
+  const title = `画像最適化 ${testInfo.project.name} ${crypto.randomUUID()}`;
+  await fillReport(page, title);
+  await page.evaluate(() => {
+    let previous = performance.now();
+    let maxDelayMs = 0;
+    let samples = 0;
+    const timer = setInterval(() => {
+      const now = performance.now();
+      maxDelayMs = Math.max(maxDelayMs, now - previous - 50);
+      previous = now;
+      samples += 1;
+    }, 50);
+    (window as typeof window & { stopImageHeartbeat: () => { maxDelayMs: number; samples: number } }).stopImageHeartbeat = () => {
+      clearInterval(timer);
+      return { maxDelayMs, samples };
+    };
+  });
+  const started = Date.now();
+  await page.locator('input[type="file"]').setInputFiles(files);
+  await expect(page.locator("#image-optimization-status")).toContainText("画像を最適化しました", { timeout: 90_000 });
+  await expect(page.locator(".attachment-item")).toHaveCount(2, { timeout: 30_000 });
+  const elapsedMs = Date.now() - started;
+  const heartbeat = await page.evaluate(() => (window as typeof window & { stopImageHeartbeat: () => { maxDelayMs: number; samples: number } }).stopImageHeartbeat());
+  expect(captured.metadata).toHaveLength(2);
+  expect(captured.uploads).toHaveLength(2);
+  const optimizedTotal = captured.metadata.reduce((sum, file) => sum + file.sizeBytes, 0);
+  expect(optimizedTotal).toBeLessThanOrEqual(10 * MiB);
+  expect(optimizedTotal).toBeLessThan(originalTotal);
+  await expect(page.locator("#image-optimization-status")).toContainText(`${(originalTotal / MiB).toFixed(2)} MiB → ${(optimizedTotal / MiB).toFixed(2)} MiB`);
+  for (const [index, upload] of captured.uploads.entries()) {
+    assertUploadMatches(captured.metadata[index], upload);
+    const decoded = await inspectImage(page, upload);
+    expect(Math.max(decoded.width, decoded.height)).toBeLessThanOrEqual(2560);
+    expect(decoded.width / decoded.height).toBeCloseTo(index === 0 ? 2600 / 1900 : 4 / 3, 2);
+    if (index === 1) {
+      expect(["image/webp", "image/png"]).toContain(upload.mimeType);
+      expect(decoded.samples[0][3]).toBe(0);
+    }
+    expect(createHash("sha256").update(files[index].buffer).digest("hex")).toBe(originalHashes[index]);
+  }
+  await page.getByLabel("画像の説明").nth(0).fill("最適化した写真");
+  await page.getByLabel("画像の説明").nth(1).fill("透過を保持した図");
+  const layout = await page.evaluate(() => ({ viewport: document.documentElement.clientWidth, content: document.documentElement.scrollWidth }));
+  expect(layout.content).toBeLessThanOrEqual(layout.viewport + 1);
+  await testInfo.attach("optimized-image-form", {
+    body: await page.locator('section[aria-labelledby="media-heading"]').screenshot(),
+    contentType: "image/png",
+  });
+  await page.getByRole("button", { name: "下書き保存", exact: true }).click();
+  await expect(page).toHaveURL(/\/reports\/[^/]+\/edit\?saved=1$/, { timeout: 90_000 });
+  const reportId = new URL(page.url()).pathname.split("/").at(-2)!;
+  const savedResponse = await page.request.get(`/api/reports/${reportId}`);
+  expect(savedResponse.ok()).toBe(true);
+  const saved = await savedResponse.json() as { attachments: UploadMetadata[] };
+  expect(saved.attachments.map(({ filename, mimeType, sizeBytes }) => ({ filename, mimeType, sizeBytes }))).toEqual(captured.metadata);
+  await page.getByRole("button", { name: "公開する", exact: true }).click();
+  await expect(page).toHaveURL(/\/reports\/[^/?]+\?published=1$/, { timeout: 90_000 });
+  for (const alt of ["最適化した写真", "透過を保持した図"]) {
+    const image = page.getByRole("img", { name: alt, exact: true });
+    await expect(image).toBeVisible();
+    await expect.poll(() => image.evaluate((element) => (element as HTMLImageElement).complete && (element as HTMLImageElement).naturalWidth > 0)).toBe(true);
+  }
+  await testInfo.attach("image-optimization-metrics", {
+    body: JSON.stringify({ browser: testInfo.project.name, originalTotal, optimizedTotal, elapsedMs, heartbeat, viewport: page.viewportSize() }, null, 2),
+    contentType: "application/json",
+  });
+});
+
+function addOrientationExif(file: ImageFile): ImageFile {
+  const camera = Buffer.from("HANABI-E2E-CAMERA-METADATA\0", "ascii");
+  const tiff = Buffer.alloc(38 + camera.length);
+  tiff.write("II", 0);
+  tiff.writeUInt16LE(42, 2);
+  tiff.writeUInt32LE(8, 4);
+  tiff.writeUInt16LE(2, 8);
+  tiff.writeUInt16LE(0x0112, 10); // Orientation: 90 degrees clockwise.
+  tiff.writeUInt16LE(3, 12);
+  tiff.writeUInt32LE(1, 14);
+  tiff.writeUInt16LE(6, 18);
+  tiff.writeUInt16LE(0x010f, 22); // Camera make (ASCII).
+  tiff.writeUInt16LE(2, 24);
+  tiff.writeUInt32LE(camera.length, 26);
+  tiff.writeUInt32LE(38, 30);
+  camera.copy(tiff, 38);
+  const payload = Buffer.concat([Buffer.from("Exif\0\0", "ascii"), tiff]);
+  const marker = Buffer.alloc(4);
+  marker.writeUInt16BE(0xffe1, 0);
+  marker.writeUInt16BE(payload.length + 2, 2);
+  return { ...file, name: "camera-orientation.jpg", buffer: Buffer.concat([file.buffer.subarray(0, 2), marker, payload, file.buffer.subarray(2)]) };
+}
+
+test("EXIFの向きを画素に反映し、メタデータを除去して小画像を拡大しない", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "webkit", "WebKitのsigned fetchはルート監視の対象外としてChromium/Mobileで検証する");
+  await openPage(page, "/reports/new");
+  const file = addOrientationExif(await canvasFile(page, "quadrants"));
+  const captured = await captureUploads(page);
+  await page.locator('input[type="file"]').setInputFiles(file);
+  await expect(page.locator(".attachment-item")).toHaveCount(1, { timeout: 30_000 });
+  expect(captured.uploads).toHaveLength(1);
+  assertUploadMatches(captured.metadata[0], captured.uploads[0]);
+  expect(captured.metadata[0].filename).toBe("camera-orientation.jpg");
+  expect(captured.uploads[0].bytes.includes(Buffer.from("Exif\0\0"))).toBe(false);
+  expect(captured.uploads[0].bytes.includes(Buffer.from("HANABI-E2E-CAMERA-METADATA"))).toBe(false);
+  const decoded = await inspectImage(page, captured.uploads[0]);
+  expect([decoded.width, decoded.height]).toEqual([80, 120]);
+  const expectedColors = [[0, 255, 0], [255, 0, 0], [255, 255, 255], [0, 0, 255]];
+  expectedColors.forEach((color, index) => {
+    color.forEach((channel, channelIndex) => expect(Math.abs(decoded.samples[index + 1][channelIndex] - channel)).toBeLessThan(15));
+  });
+});
+
+test("画像の読み込み・再エンコードに失敗しても原本を送らず、再選択で復帰できる", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "webkit", "WebKitのsigned fetchはルート監視の対象外としてChromium/Mobileで検証する");
+  await openPage(page, "/reports/new");
+  const captured = await captureUploads(page);
+  const input = page.locator('input[type="file"]');
+  await input.setInputFiles({ name: "broken.jpg", mimeType: "image/jpeg", buffer: Buffer.from("not an image") });
+  await expect(page.locator("#attachments-error")).toBeVisible();
+  expect(captured.metadata).toHaveLength(0);
+  expect(captured.uploads).toHaveLength(0);
+
+  const valid = await canvasFile(page, "quadrants");
+  await page.evaluate(() => {
+    const original = HTMLCanvasElement.prototype.toBlob;
+    (window as typeof window & { restoreEncoder: () => void }).restoreEncoder = () => { HTMLCanvasElement.prototype.toBlob = original; };
+    HTMLCanvasElement.prototype.toBlob = function (callback) { queueMicrotask(() => callback(null)); };
+  });
+  await input.setInputFiles(valid);
+  await expect(page.locator("#attachments-error")).toBeVisible();
+  await expect(input).toBeEnabled();
+  expect(captured.metadata).toHaveLength(0);
+  expect(captured.uploads).toHaveLength(0);
+  await page.evaluate(() => (window as typeof window & { restoreEncoder: () => void }).restoreEncoder());
+  await input.setInputFiles(valid);
+  await expect(page.locator(".attachment-item")).toHaveCount(1, { timeout: 30_000 });
+  await expect(page.locator("#attachments-error")).toHaveCount(0);
+  expect(captured.uploads).toHaveLength(1);
+});
+
+async function seedNearlyFullDraft(page: Page, image: ImageFile) {
+  const attachments = [];
+  for (const [index, sizeBytes] of [5 * MiB, 5 * MiB - 1024].entries()) {
+    // A valid JPEG with harmless trailing padding creates exact existing byte budgets.
+    const bytes = Buffer.alloc(sizeBytes);
+    image.buffer.copy(bytes);
+    const filename = `existing-${index}.jpg`;
+    const grantResponse = await page.request.post("/api/uploads", { data: { filename, mimeType: "image/jpeg", sizeBytes } });
+    expect(grantResponse.ok()).toBe(true);
+    const grant = await grantResponse.json() as { storagePath: string; signedUrl: string };
+    const uploaded = await page.request.put(grant.signedUrl, { data: bytes, headers: { "Content-Type": "image/jpeg" } });
+    expect(uploaded.ok()).toBe(true);
+    attachments.push({ storagePath: grant.storagePath, filename, mimeType: "image/jpeg", sizeBytes, altText: "既存の説明", sortOrder: index });
+  }
+  const reportDate = await page.locator("#reportDate").inputValue();
+  const response = await page.request.post("/api/reports", {
+    headers: { "Idempotency-Key": crypto.randomUUID() },
+    data: { reportDate, title: "残容量と処理中の操作", activityArea: "ロボット", contentCategory: "進捗", activityText: "既存画像の残容量を検証する。", attachments },
+  });
+  expect(response.ok()).toBe(true);
+  return await response.json() as { id: string };
+}
+
+test("既存画像の残容量を守り、処理中の保存・二重選択を防いで入力を維持する", async ({ page }, testInfo) => {
+  test.skip(testInfo.project.name === "webkit", "WebKitのsigned fetchはルート監視の対象外としてChromium/Mobileで検証する");
+  await openPage(page, "/reports/new");
+  const original = await canvasFile(page, "quadrants");
+  const draft = await seedNearlyFullDraft(page, original);
+  await openPage(page, `/reports/${draft.id}/edit`);
+  const noise = await canvasFile(page, "noise");
+  const captured = await captureUploads(page);
+  const input = page.locator('input[type="file"]');
+  await input.setInputFiles(noise);
+  await expect(page.locator("#attachments-error")).toBeVisible({ timeout: 30_000 });
+  expect(captured.metadata).toHaveLength(0);
+  expect(captured.uploads).toHaveLength(0);
+  await expect(page.locator(".attachment-item")).toHaveCount(2);
+  await page.getByRole("button", { name: "existing-0.jpgを削除", exact: true }).click();
+
+  await page.evaluate(() => {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    (window as typeof window & { releaseEncoding: () => void }).releaseEncoding = release;
+    const original = HTMLCanvasElement.prototype.toBlob;
+    HTMLCanvasElement.prototype.toBlob = function (callback, type, quality) {
+      original.call(this, (blob) => { void gate.then(() => callback(blob)); }, type, quality);
+    };
+  });
+  let saveRequests = 0;
+  page.on("request", (request) => {
+    if (new URL(request.url()).pathname === `/api/reports/${draft.id}` && request.method() === "PATCH") saveRequests += 1;
+  });
+  await input.setInputFiles(noise);
+  await expect(page.locator("#image-optimization-status")).toContainText("画像を最適化しています…");
+  await expect(page.locator("#image-optimization-status")).toHaveAttribute("aria-live", "polite");
+  await expect(input).toBeDisabled();
+  await expect(page.getByRole("button", { name: "下書き保存", exact: true })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "公開する", exact: true })).toBeDisabled();
+  await expect(page.getByRole("button", { name: "existing-1.jpgを削除", exact: true })).toBeDisabled();
+  await page.getByLabel("タイトル任意").fill("最適化中に編集したタイトル");
+  await page.getByLabel("画像の説明").fill("最適化中に編集した既存画像の説明");
+  // Programmatically emitted events also exercise the synchronous guards, beyond disabled controls.
+  await page.evaluate(() => {
+    document.querySelector("form.report-form")!.dispatchEvent(new Event("submit", { bubbles: true, cancelable: true }));
+    const input = document.querySelector<HTMLInputElement>('input[type="file"]')!;
+    const transfer = new DataTransfer();
+    transfer.items.add(new File(["invalid duplicate selection"], "duplicate.jpg", { type: "image/jpeg" }));
+    input.files = transfer.files;
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+  expect(saveRequests).toBe(0);
+  expect(captured.metadata).toHaveLength(0);
+  await page.evaluate(() => (window as typeof window & { releaseEncoding: () => void }).releaseEncoding());
+  await expect(page.locator(".attachment-item")).toHaveCount(2, { timeout: 30_000 });
+  expect(captured.uploads).toHaveLength(1);
+  expect(captured.metadata[0].sizeBytes + 5 * MiB - 1024).toBeLessThanOrEqual(10 * MiB);
+  await expect(page.getByLabel("タイトル任意")).toHaveValue("最適化中に編集したタイトル");
+  await expect(page.getByLabel("画像の説明").first()).toHaveValue("最適化中に編集した既存画像の説明");
+  await page.getByRole("button", { name: "下書き保存", exact: true }).click();
+  await expect(page).toHaveURL(new RegExp(`/reports/${draft.id}/edit\\?saved=1$`), { timeout: 90_000 });
+  expect(saveRequests).toBe(1);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1874,6 +1874,23 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@rolldown/binding-freebsd-x64": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
@@ -1899,6 +1916,26 @@
         "arm"
       ],
       "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
     url: "http://127.0.0.1:3000",
     reuseExistingServer: !process.env.CI,
     env: {
+      // Demo signed-upload URLs must use the same origin as Playwright. CI sets
+      // APP_BASE_URL to localhost, which is a different CSP origin from 127.0.0.1.
+      APP_BASE_URL: "http://127.0.0.1:3000",
       DEMO_MODE: "true",
       SLACK_BOT_TOKEN: "",
       SLACK_CHANNEL_ID: "",

--- a/src/components/report-form.tsx
+++ b/src/components/report-form.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useMemo, useRef, useState, type ChangeEvent, type FormEvent } from "react";
 import { ACTIVITY_AREAS, CONTENT_CATEGORIES, THEME_TAGS, type ThemeTag } from "@/lib/constants";
 import { todayInJst } from "@/lib/text";
+import { optimizeImages } from "@/lib/images/optimize-images";
 import type { Attachment, CurrentUser, RelatedLink, Report, ReportInput } from "@/lib/types";
 import { apiRequest, ClientApiError, makeIdempotencyKey } from "@/components/api-client";
 import { AlertIcon, ArrowLeftIcon, CheckIcon, ImageIcon, LinkIcon, PlusIcon, TrashIcon, XIcon } from "@/components/icons";
@@ -84,12 +85,16 @@ export function ReportForm({
   const [values, setValues] = useState<FormValues>(() => initialValues(initialReport));
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState<"draft" | "publish" | "delete" | null>(null);
-  const [uploading, setUploading] = useState(false);
+  const [imagePhase, setImagePhase] = useState<"optimizing" | "uploading" | null>(null);
+  const [optimizationSummary, setOptimizationSummary] = useState<{ originalSize: number; optimizedSize: number } | null>(null);
+  const [originalImageSizes, setOriginalImageSizes] = useState<Record<string, number>>({});
   const [notice, setNotice] = useState<string | null>(initialNotice ?? null);
   const [globalError, setGlobalError] = useState<string | null>(null);
   const errorSummaryRef = useRef<HTMLDivElement>(null);
   const createKey = useRef(makeIdempotencyKey("create-report"));
   const publishKey = useRef(makeIdempotencyKey("publish-report"));
+  const imageController = useRef<AbortController | null>(null);
+  const uploading = imagePhase !== null;
 
   const isPublished = report?.status === "published";
   const isPendingApproval = report?.status === "pending_approval";
@@ -105,8 +110,10 @@ export function ReportForm({
     return () => controller.abort();
   }, []);
 
+  useEffect(() => () => imageController.current?.abort(), []);
+
   async function deleteDraft() {
-    if (!report || !currentUser || !canDeleteReport(currentUser, report) || busy || uploading) return;
+    if (!report || !currentUser || !canDeleteReport(currentUser, report) || busy || imageController.current) return;
     if (!window.confirm(`「${report.title}」の下書きを削除しますか？この操作は元に戻せません。`)) return;
     setBusy("delete");
     setGlobalError(null);
@@ -149,33 +156,33 @@ export function ReportForm({
   async function uploadImages(event: ChangeEvent<HTMLInputElement>) {
     const files = Array.from(event.target.files || []);
     event.target.value = "";
-    if (!files.length) return;
+    if (!files.length || imageController.current || busy || isArchived) return;
     setGlobalError(null);
-
-    const invalid = files.find((file) => !["image/jpeg", "image/png", "image/webp"].includes(file.type));
-    if (invalid) {
-      setErrors((current) => ({ ...current, attachments: "JPEG、PNG、WebP形式の画像を選んでください" }));
-      return;
-    }
-    if (files.some((file) => file.size > 5 * 1024 * 1024)) {
-      setErrors((current) => ({ ...current, attachments: "画像は1件5MiB以内にしてください" }));
-      return;
-    }
-    if (totalImageSize + files.reduce((sum, file) => sum + file.size, 0) > 10 * 1024 * 1024) {
-      setErrors((current) => ({ ...current, attachments: "画像は合計10MiB以内にしてください" }));
-      return;
-    }
-
-    setUploading(true);
+    setErrors((current) => ({ ...current, attachments: "" }));
+    setOptimizationSummary(null);
+    const controller = new AbortController();
+    imageController.current = controller;
+    setImagePhase("optimizing");
     try {
+      // Existing attachments consume part of the report's budget, including when editing.
+      const optimized = await optimizeImages(files, {
+        maxFileBytes: 5 * 1024 * 1024,
+        maxTotalBytes: 10 * 1024 * 1024 - totalImageSize,
+        signal: controller.signal,
+      });
+      controller.signal.throwIfAborted();
+      setImagePhase("uploading");
       const uploaded: Attachment[] = [];
-      for (const file of files) {
+      for (const { file } of optimized) {
+        controller.signal.throwIfAborted();
         const signed = await apiRequest<UploadResponse>("/api/uploads", {
           method: "POST",
+          signal: controller.signal,
           body: JSON.stringify({ filename: file.name, mimeType: file.type, sizeBytes: file.size }),
         });
         const uploadResponse = await fetch(signed.signedUrl, {
           method: "PUT",
+          signal: controller.signal,
           body: file,
           headers: { "Content-Type": file.type },
         });
@@ -189,12 +196,23 @@ export function ReportForm({
           sortOrder: values.attachments.length + uploaded.length,
         });
       }
-      update("attachments", [...values.attachments, ...uploaded]);
+      controller.signal.throwIfAborted();
+      setValues((current) => ({ ...current, attachments: [...current.attachments, ...uploaded] }));
+      setOriginalImageSizes((current) => ({
+        ...current,
+        ...Object.fromEntries(uploaded.map((attachment, index) => [attachment.storagePath, optimized[index].originalSize])),
+      }));
+      setOptimizationSummary({
+        originalSize: optimized.reduce((sum, result) => sum + result.originalSize, 0),
+        optimizedSize: optimized.reduce((sum, result) => sum + result.optimizedSize, 0),
+      });
       setErrors((current) => ({ ...current, attachments: "" }));
     } catch (cause) {
+      if (controller.signal.aborted) return;
       setErrors((current) => ({ ...current, attachments: cause instanceof Error ? cause.message : "画像をアップロードできませんでした" }));
     } finally {
-      setUploading(false);
+      if (imageController.current === controller) imageController.current = null;
+      if (!controller.signal.aborted) setImagePhase(null);
     }
   }
 
@@ -203,7 +221,9 @@ export function ReportForm({
   }
 
   function removeAttachment(index: number) {
+    if (imageController.current || busy || isArchived) return;
     update("attachments", values.attachments.filter((_, attachmentIndex) => attachmentIndex !== index));
+    setOptimizationSummary(null);
   }
 
   function basicClientValidation(): Record<string, string> {
@@ -218,6 +238,7 @@ export function ReportForm({
 
   async function submit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    if (imageController.current || busy || isArchived) return;
     const submitter = (event.nativeEvent as SubmitEvent).submitter as HTMLButtonElement | null;
     const intent = submitter?.value === "publish" ? "publish" : "draft";
     const validationErrors = basicClientValidation();
@@ -366,16 +387,19 @@ export function ReportForm({
             <div className="field">
               <div className="field__label"><span className="label-like">画像<span className="optional-mark">任意</span></span><span className="counter">{(totalImageSize / 1024 / 1024).toFixed(1)} / 10 MiB</span></div>
               <label className={`upload-zone${uploading ? " upload-zone--busy" : ""}`}>
-                <input accept="image/jpeg,image/png,image/webp" disabled={uploading || totalImageSize >= 10 * 1024 * 1024} multiple onChange={(event) => void uploadImages(event)} type="file" />
+                <input accept="image/jpeg,image/png,image/webp" aria-describedby={errors.attachments ? "attachments-error image-optimization-status" : "image-optimization-status"} aria-invalid={Boolean(errors.attachments)} disabled={uploading || Boolean(busy) || isArchived || totalImageSize >= 10 * 1024 * 1024} multiple onChange={(event) => void uploadImages(event)} type="file" />
                 <span className="upload-zone__icon"><ImageIcon /></span>
-                <span><strong>{uploading ? "アップロードしています…" : "画像を選ぶ"}</strong><small>JPEG・PNG・WebP / 1件5MiB、合計10MiBまで</small></span>
+                <span><strong>{imagePhase === "optimizing" ? "画像を最適化しています…" : uploading ? "アップロードしています…" : "画像を選ぶ"}</strong><small>JPEG・PNG・WebP / 自動最適化後に1件5MiB、合計10MiBまで</small></span>
               </label>
-              {errors.attachments ? <p className="field-error">{errors.attachments}</p> : null}
+              <p aria-live="polite" aria-atomic="true" className="field-help" id="image-optimization-status">
+                {imagePhase === "optimizing" ? "画像を最適化しています…" : uploading ? "最適化した画像をアップロードしています…" : optimizationSummary ? `画像を最適化しました（今回選択した画像）：${(optimizationSummary.originalSize / 1024 / 1024).toFixed(2)} MiB → ${(optimizationSummary.optimizedSize / 1024 / 1024).toFixed(2)} MiB` : "画像を選ぶと自動でサイズを調整します。端末の元画像は変更されません。"}
+              </p>
+              {errors.attachments ? <p className="field-error" id="attachments-error" role="alert">{errors.attachments}</p> : null}
               {values.attachments.length ? <div className="attachment-list">{values.attachments.map((attachment, index) => (
                 <div className="attachment-item" key={`${attachment.storagePath}-${index}`}>
                   <span className="attachment-item__thumb"><ImageIcon /></span>
-                  <div className="attachment-item__body"><div><strong>{attachment.filename}</strong><small>{(attachment.sizeBytes / 1024 / 1024).toFixed(1)} MiB</small></div><label><span>画像の説明</span><input maxLength={300} onChange={(event) => updateAttachmentAlt(index, event.target.value)} placeholder="例：組み立て後の駆動系" value={attachment.altText || ""} /></label></div>
-                  <button aria-label={`${attachment.filename}を削除`} className="icon-button" onClick={() => removeAttachment(index)} type="button"><XIcon /></button>
+                  <div className="attachment-item__body"><div><strong>{attachment.filename}</strong><small>{originalImageSizes[attachment.storagePath] !== undefined ? `${(originalImageSizes[attachment.storagePath] / 1024 / 1024).toFixed(2)} MiB → ` : ""}{(attachment.sizeBytes / 1024 / 1024).toFixed(2)} MiB</small></div><label><span>画像の説明</span><input maxLength={300} onChange={(event) => updateAttachmentAlt(index, event.target.value)} placeholder="例：組み立て後の駆動系" value={attachment.altText || ""} /></label></div>
+                  <button aria-label={`${attachment.filename}を削除`} className="icon-button" disabled={uploading || Boolean(busy) || isArchived} onClick={() => removeAttachment(index)} type="button"><XIcon /></button>
                 </div>
               ))}</div> : null}
             </div>

--- a/src/lib/images/optimize-images-animation.test.ts
+++ b/src/lib/images/optimize-images-animation.test.ts
@@ -15,6 +15,12 @@ function concat(...parts: Uint8Array[]): Uint8Array {
   return result;
 }
 
+function asArrayBuffer(bytes: Uint8Array): ArrayBuffer {
+  const copy = new Uint8Array(bytes.byteLength);
+  copy.set(bytes);
+  return copy.buffer as ArrayBuffer;
+}
+
 function pngChunk(type: string, data: Uint8Array): Uint8Array {
   const header = new Uint8Array(8);
   new DataView(header.buffer).setUint32(0, data.length, false);
@@ -29,9 +35,8 @@ function animatedPng(): File {
   const actl = new Uint8Array(8);
   new DataView(actl.buffer).setUint32(0, 2, false);
   new DataView(actl.buffer).setUint32(4, 0, false);
-  return new File([concat(signature, pngChunk("acTL", actl), pngChunk("IDAT", new Uint8Array()))], "animated.png", {
-    type: "image/png",
-  });
+  const bytes = concat(signature, pngChunk("acTL", actl), pngChunk("IDAT", new Uint8Array()));
+  return new File([asArrayBuffer(bytes)], "animated.png", { type: "image/png" });
 }
 
 function animatedWebp(): File {
@@ -44,7 +49,8 @@ function animatedWebp(): File {
   const riff = new Uint8Array(8);
   riff.set(ascii("RIFF"), 0);
   new DataView(riff.buffer).setUint32(4, payload.length, true);
-  return new File([concat(riff, payload)], "animated.webp", { type: "image/webp" });
+  const bytes = concat(riff, payload);
+  return new File([asArrayBuffer(bytes)], "animated.webp", { type: "image/webp" });
 }
 
 afterEach(() => {

--- a/src/lib/images/optimize-images-animation.test.ts
+++ b/src/lib/images/optimize-images-animation.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { optimizeImages } from "@/lib/images/optimize-images";
+
+function ascii(value: string): Uint8Array {
+  return Uint8Array.from([...value].map((character) => character.charCodeAt(0)));
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const result = new Uint8Array(parts.reduce((total, part) => total + part.length, 0));
+  let offset = 0;
+  for (const part of parts) {
+    result.set(part, offset);
+    offset += part.length;
+  }
+  return result;
+}
+
+function pngChunk(type: string, data: Uint8Array): Uint8Array {
+  const header = new Uint8Array(8);
+  new DataView(header.buffer).setUint32(0, data.length, false);
+  header.set(ascii(type), 4);
+  // CRC is irrelevant to the lightweight animation detector; the browser is
+  // never asked to decode these fixtures because they must be rejected first.
+  return concat(header, data, new Uint8Array(4));
+}
+
+function animatedPng(): File {
+  const signature = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  const actl = new Uint8Array(8);
+  new DataView(actl.buffer).setUint32(0, 2, false);
+  new DataView(actl.buffer).setUint32(4, 0, false);
+  return new File([concat(signature, pngChunk("acTL", actl), pngChunk("IDAT", new Uint8Array()))], "animated.png", {
+    type: "image/png",
+  });
+}
+
+function animatedWebp(): File {
+  const vp8xData = new Uint8Array(10);
+  vp8xData[0] = 0x02; // WebP VP8X animation feature flag.
+  const chunkHeader = new Uint8Array(8);
+  chunkHeader.set(ascii("VP8X"), 0);
+  new DataView(chunkHeader.buffer).setUint32(4, vp8xData.length, true);
+  const payload = concat(ascii("WEBP"), chunkHeader, vp8xData);
+  const riff = new Uint8Array(8);
+  riff.set(ascii("RIFF"), 0);
+  new DataView(riff.buffer).setUint32(4, payload.length, true);
+  return new File([concat(riff, payload)], "animated.webp", { type: "image/webp" });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("animated image protection", () => {
+  it("rejects APNG before decoding so canvas re-encoding cannot silently drop frames", async () => {
+    const createBitmap = vi.fn();
+    vi.stubGlobal("createImageBitmap", createBitmap);
+
+    await expect(optimizeImages([animatedPng()])).rejects.toThrow("アニメーション画像");
+    expect(createBitmap).not.toHaveBeenCalled();
+  });
+
+  it("rejects Animated WebP before decoding so canvas re-encoding cannot silently drop frames", async () => {
+    const createBitmap = vi.fn();
+    vi.stubGlobal("createImageBitmap", createBitmap);
+
+    await expect(optimizeImages([animatedWebp()])).rejects.toThrow("アニメーション画像");
+    expect(createBitmap).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/images/optimize-images.test.ts
+++ b/src/lib/images/optimize-images.test.ts
@@ -1,0 +1,331 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { optimizeImages } from "@/lib/images/optimize-images";
+
+const MiB = 1024 * 1024;
+
+function inputFile(name = "photo.jpg", type = "image/jpeg", size = 2 * MiB) {
+  return new File([new Uint8Array(size)], name, { type, lastModified: 1234 });
+}
+
+type Encoding = {
+  filename: string;
+  width: number;
+  height: number;
+  type: string;
+  quality: number;
+};
+
+function browserHarness(options: {
+  width?: number;
+  height?: number;
+  encode?: (encoding: Encoding) => Blob | null;
+  noContext?: boolean;
+  drawError?: boolean;
+} = {}) {
+  const encodings: Encoding[] = [];
+  const bitmaps: { file: File; width: number; height: number; close: ReturnType<typeof vi.fn> }[] = [];
+  let activeDecodes = 0;
+  let peakDecodes = 0;
+  const createBitmap = vi.fn(async (file: File) => {
+    activeDecodes += 1;
+    peakDecodes = Math.max(peakDecodes, activeDecodes);
+    const bitmap = {
+      file,
+      width: options.width ?? 4032,
+      height: options.height ?? 3024,
+      close: vi.fn(() => { activeDecodes -= 1; }),
+    };
+    bitmaps.push(bitmap);
+    return bitmap;
+  });
+  const canvases: { width: number; height: number; getContext: ReturnType<typeof vi.fn>; toBlob: ReturnType<typeof vi.fn> }[] = [];
+  vi.stubGlobal("createImageBitmap", createBitmap);
+  vi.stubGlobal("document", {
+    createElement: vi.fn((tag: string) => {
+      expect(tag).toBe("canvas");
+      let filename = "fallback";
+      const context = {
+        imageSmoothingEnabled: false,
+        imageSmoothingQuality: "low",
+        drawImage: vi.fn((source: { file?: File }) => {
+          if (options.drawError) throw new Error("draw failed");
+          filename = source.file?.name ?? "fallback";
+        }),
+      };
+      const canvas = {
+        width: 0,
+        height: 0,
+        getContext: vi.fn(() => options.noContext ? null : context),
+        toBlob: vi.fn((callback: BlobCallback, type: string, quality: number) => {
+          const encoding = { filename, width: canvas.width, height: canvas.height, type, quality };
+          encodings.push(encoding);
+          const blob = options.encode ? options.encode(encoding) : new Blob(["encoded pixels"], { type });
+          queueMicrotask(() => callback(blob));
+        }),
+      };
+      canvases.push(canvas);
+      return canvas;
+    }),
+  });
+  return { encodings, bitmaps, canvases, createBitmap, peakDecodes: () => peakDecodes };
+}
+
+function imageElementFallback(mode: "load" | "error" | "pending" = "load") {
+  const createObjectURL = vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:test-image");
+  const revokeObjectURL = vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+  const instances: FakeImage[] = [];
+  class FakeImage {
+    naturalWidth = 600;
+    naturalHeight = 800;
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    currentSource = "";
+    constructor() { instances.push(this); }
+    set src(value: string) {
+      this.currentSource = value;
+      if (value) queueMicrotask(() => {
+        if (mode === "load") this.onload?.();
+        if (mode === "error") this.onerror?.();
+      });
+    }
+  }
+  vi.stubGlobal("Image", FakeImage);
+  return { createObjectURL, revokeObjectURL, instances };
+}
+
+function blobOfSize(size: number, type = "image/jpeg") {
+  return new Blob([new Uint8Array(size)], { type });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("optimizeImages", () => {
+  it("re-encodes a small image once without enlarging it or changing the original", async () => {
+    const browser = browserHarness({ width: 800, height: 600 });
+    const original = inputFile("trip.JPEG");
+    const originalBytes = await original.arrayBuffer();
+    const [result] = await optimizeImages([original]);
+
+    expect(browser.encodings).toEqual([{ filename: "trip.JPEG", width: 800, height: 600, type: "image/jpeg", quality: 0.82 }]);
+    expect(result).toMatchObject({ originalSize: 2 * MiB, originalMimeType: "image/jpeg", optimizedMimeType: "image/jpeg", width: 800, height: 600 });
+    expect(result.file).not.toBe(original);
+    expect(result.file.name).toBe("trip.JPEG");
+    expect(result.file.lastModified).toBe(1234);
+    expect(await original.arrayBuffer()).toEqual(originalBytes);
+    expect(original.name).toBe("trip.JPEG");
+    expect(original.type).toBe("image/jpeg");
+    expect(original.size).toBe(2 * MiB);
+    expect(result.optimizedSize).toBe(result.file.size);
+  });
+
+  it("resizes a large image proportionally and continues until the per-file limit is met", async () => {
+    const browser = browserHarness({ encode: ({ quality }) => blobOfSize(quality === 0.82 ? 6 * MiB : 5 * MiB) });
+    const original = inputFile("large.jpg", "image/jpeg", 8 * MiB);
+    const [result] = await optimizeImages([original]);
+
+    expect(result.file.size).toBe(5 * MiB);
+    expect(result.width).toBe(2560);
+    expect(result.height).toBe(1920);
+    expect(browser.encodings.map(({ quality }) => quality)).toEqual([0.82, 0.75]);
+    expect(browser.createBitmap).toHaveBeenNthCalledWith(1, original, { imageOrientation: "from-image" });
+    expect(browser.createBitmap).toHaveBeenNthCalledWith(2, original, { imageOrientation: "from-image" });
+  });
+
+  it("applies extra compression fairly to all images until their combined size fits", async () => {
+    const browser = browserHarness({ encode: ({ quality }) => blobOfSize(quality === 0.82 ? 4 * MiB : 3 * MiB) });
+    const originals = ["a.jpg", "b.jpg", "c.jpg"].map((name) => inputFile(name, "image/jpeg", 4 * MiB));
+    const results = await optimizeImages(originals);
+
+    expect(results.reduce((sum, image) => sum + image.file.size, 0)).toBe(9 * MiB);
+    expect(browser.encodings.map(({ filename, quality }) => [filename, quality])).toEqual([
+      ["a.jpg", 0.82], ["b.jpg", 0.82], ["c.jpg", 0.82],
+      ["a.jpg", 0.75], ["b.jpg", 0.75], ["c.jpg", 0.75],
+    ]);
+    expect(browser.peakDecodes()).toBe(1);
+    expect(browser.bitmaps.every((bitmap) => bitmap.close.mock.calls.length === 1)).toBe(true);
+    expect(browser.canvases.every((canvas) => canvas.width === 0 && canvas.height === 0)).toBe(true);
+  });
+
+  it("uses the remaining report budget rather than the default total limit", async () => {
+    browserHarness({ encode: ({ quality }) => blobOfSize(quality > 0.68 ? 2 * MiB : MiB) });
+    const results = await optimizeImages([inputFile("a.jpg"), inputFile("b.jpg")], { maxTotalBytes: 2 * MiB });
+    expect(results.reduce((sum, image) => sum + image.file.size, 0)).toBe(2 * MiB);
+  });
+
+  it("honors a tighter per-file budget even when the total already fits", async () => {
+    browserHarness({ encode: ({ quality }) => blobOfSize(quality === 0.82 ? 2 * MiB : MiB) });
+    const [result] = await optimizeImages([inputFile()], { maxFileBytes: MiB });
+    expect(result.file.size).toBe(MiB);
+  });
+
+  it("rejects an impossible total after bounded passes down to the minimum dimension", async () => {
+    const browser = browserHarness({ encode: () => blobOfSize(4 * MiB) });
+    await expect(optimizeImages([inputFile("a.jpg"), inputFile("b.jpg"), inputFile("c.jpg")])).rejects.toThrow("画像の枚数を減らすか");
+
+    expect(browser.encodings).toHaveLength(18);
+    expect(browser.encodings.filter(({ filename }) => filename === "a.jpg").map(({ width, height, quality }) => [width, height, quality])).toEqual([
+      [2560, 1920, 0.82], [2560, 1920, 0.75], [2560, 1920, 0.68],
+      [2560, 1920, 0.62], [2048, 1536, 0.62], [1600, 1200, 0.62],
+    ]);
+    expect(browser.bitmaps.every((bitmap) => bitmap.close.mock.calls.length === 1)).toBe(true);
+  });
+
+  it("reduces dimensions when lowering quality is insufficient", async () => {
+    const browser = browserHarness({ encode: ({ width }) => blobOfSize(width > 2048 ? 6 * MiB : 4 * MiB) });
+    const [result] = await optimizeImages([inputFile()]);
+    expect(result).toMatchObject({ width: 2048, height: 1536, optimizedSize: 4 * MiB });
+    expect(browser.encodings).toHaveLength(5);
+  });
+
+  it("keeps a smaller previous re-encoding if a later encoder result unexpectedly grows", async () => {
+    browserHarness({
+      encode: ({ filename, quality }) => blobOfSize(filename === "a.jpg" ? (quality === 0.82 ? 2 : 3) * MiB : (quality === 0.82 ? 5 : 3) * MiB),
+    });
+    const results = await optimizeImages([inputFile("a.jpg"), inputFile("b.jpg")], { maxTotalBytes: 5 * MiB });
+    expect(results.map((image) => image.file.size)).toEqual([2 * MiB, 3 * MiB]);
+  });
+
+  it("always returns newly encoded pixels, even when a tiny original would be smaller", async () => {
+    browserHarness();
+    const original = inputFile("tiny.jpg", "image/jpeg", 1);
+    const [result] = await optimizeImages([original]);
+    expect(result.file).not.toBe(original);
+    expect(result.file.size).toBeGreaterThan(original.size);
+  });
+
+  it.each([
+    ["diagram.png", "image/png", "diagram.webp"],
+    ["photo.wrong", "image/webp", "photo.webp"],
+    ["photo.png", "image/jpeg", "photo.jpg"],
+    ["photo", "image/jpeg", "photo.jpg"],
+    ["jpg", "image/jpeg", "jpg.jpg"],
+    ["jpeg", "image/jpeg", "jpeg.jpg"],
+    ["webp", "image/webp", "webp.webp"],
+  ])("uses a matching MIME type and extension for %s", async (name, type, expectedName) => {
+    const browser = browserHarness();
+    const [result] = await optimizeImages([inputFile(name, type)]);
+    const expectedMime = type === "image/jpeg" ? "image/jpeg" : "image/webp";
+    expect(browser.encodings[0].type).toBe(expectedMime);
+    expect(result.file.name).toBe(expectedName);
+    expect(result.file.type).toBe(expectedMime);
+    expect(result.optimizedMimeType).toBe(expectedMime);
+  });
+
+  it("keeps a renamed PNG within the API filename limit without splitting Unicode characters", async () => {
+    browserHarness();
+    const original = inputFile(`${"a".repeat(249)}📸.png`, "image/png");
+    expect(original.name.length).toBe(255);
+    const [result] = await optimizeImages([original]);
+    expect(result.file.name).toBe(`${"a".repeat(249)}.webp`);
+    expect(result.file.name.length).toBeLessThanOrEqual(255);
+    expect(original.name).toBe(`${"a".repeat(249)}📸.png`);
+  });
+
+  it("accepts Safari's PNG encoder fallback and preserves its actual format", async () => {
+    const browser = browserHarness({ encode: () => blobOfSize(100, "image/png") });
+    const [result] = await optimizeImages([inputFile("alpha.webp", "image/webp")]);
+    expect(browser.encodings[0].type).toBe("image/webp");
+    expect(result.file.name).toBe("alpha.png");
+    expect(result.file.type).toBe("image/png");
+    expect(result.originalMimeType).toBe("image/webp");
+  });
+
+  it.each([null, new Blob([], { type: "image/jpeg" }), new Blob(["bad"], { type: "image/gif" })])("rejects invalid encoder output and releases resources", async (output) => {
+    const browser = browserHarness({ encode: () => output });
+    await expect(optimizeImages([inputFile()])).rejects.toThrow("最適化できませんでした");
+    expect(browser.bitmaps[0].close).toHaveBeenCalledOnce();
+    expect(browser.canvases[0]).toMatchObject({ width: 0, height: 0 });
+  });
+
+  it.each([{ noContext: true }, { drawError: true }, { width: 0 }])("releases a decoded image after canvas or dimension failures: %j", async (options) => {
+    const browser = browserHarness(options);
+    await expect(optimizeImages([inputFile()])).rejects.toThrow();
+    expect(browser.bitmaps[0].close).toHaveBeenCalledOnce();
+    expect(browser.canvases.every((canvas) => canvas.width === 0 && canvas.height === 0)).toBe(true);
+  });
+
+  it.each(["image/gif", "image/heic", "image/svg+xml", ""])("rejects unsupported MIME %s before any decoding", async (type) => {
+    const browser = browserHarness();
+    await expect(optimizeImages([inputFile("file", type)])).rejects.toThrow("JPEG・PNG・WebP");
+    expect(browser.createBitmap).not.toHaveBeenCalled();
+  });
+
+  it.each([0, -1, Number.NaN])("rejects an unusable remaining budget of %s without decoding", async (maxTotalBytes) => {
+    const browser = browserHarness();
+    await expect(optimizeImages([inputFile()], { maxTotalBytes })).rejects.toThrow("容量上限");
+    expect(browser.createBitmap).not.toHaveBeenCalled();
+  });
+
+  it("does not let option overrides exceed server limits", async () => {
+    const browser = browserHarness({ encode: () => blobOfSize(6 * MiB) });
+    await expect(optimizeImages([inputFile()], { maxFileBytes: 10 * MiB, maxTotalBytes: 20 * MiB })).rejects.toThrow("容量上限");
+    expect(browser.encodings).toHaveLength(6);
+  });
+
+  it("returns an empty selection without allocating browser resources", async () => {
+    const browser = browserHarness();
+    expect(await optimizeImages([], { maxTotalBytes: 0 })).toEqual([]);
+    expect(browser.createBitmap).not.toHaveBeenCalled();
+  });
+
+  it("uses HTMLImageElement when ImageBitmap decoding fails and revokes the URL", async () => {
+    const browser = browserHarness();
+    browser.createBitmap.mockRejectedValue(new Error("unsupported bitmap options"));
+    const fallback = imageElementFallback();
+    const [result] = await optimizeImages([inputFile()]);
+    expect(result).toMatchObject({ width: 600, height: 800 });
+    expect(fallback.createObjectURL).toHaveBeenCalledOnce();
+    expect(fallback.revokeObjectURL).toHaveBeenCalledWith("blob:test-image");
+    expect(fallback.instances[0].currentSource).toBe("");
+    expect(fallback.instances[0].onload).toBeNull();
+    expect(fallback.instances[0].onerror).toBeNull();
+  });
+
+  it("releases a fallback URL after a corrupt image fails to load", async () => {
+    browserHarness();
+    vi.stubGlobal("createImageBitmap", undefined);
+    const fallback = imageElementFallback("error");
+    await expect(optimizeImages([inputFile()])).rejects.toThrow("読み込めませんでした");
+    expect(fallback.revokeObjectURL).toHaveBeenCalledOnce();
+    expect(fallback.instances[0].currentSource).toBe("");
+  });
+
+  it("does not decode anything when already aborted", async () => {
+    const browser = browserHarness();
+    const controller = new AbortController();
+    controller.abort();
+    await expect(optimizeImages([inputFile()], { signal: controller.signal })).rejects.toMatchObject({ name: "AbortError" });
+    expect(browser.createBitmap).not.toHaveBeenCalled();
+  });
+
+  it("stops after the active encoder and releases its resources when cancelled", async () => {
+    const controller = new AbortController();
+    const browser = browserHarness({ encode: () => {
+      controller.abort();
+      return blobOfSize(100);
+    } });
+    await expect(optimizeImages([inputFile("a.jpg"), inputFile("b.jpg")], { signal: controller.signal })).rejects.toMatchObject({ name: "AbortError" });
+    expect(browser.createBitmap).toHaveBeenCalledOnce();
+    expect(browser.bitmaps[0].close).toHaveBeenCalledOnce();
+    expect(browser.canvases[0]).toMatchObject({ width: 0, height: 0 });
+  });
+
+  it("releases a fallback image and URL when cancellation interrupts loading", async () => {
+    browserHarness();
+    vi.stubGlobal("createImageBitmap", undefined);
+    const fallback = imageElementFallback("pending");
+    const controller = new AbortController();
+    const pending = optimizeImages([inputFile()], { signal: controller.signal });
+    const rejected = expect(pending).rejects.toMatchObject({ name: "AbortError" });
+    await vi.waitFor(() => expect(fallback.createObjectURL).toHaveBeenCalledOnce());
+    controller.abort();
+    await rejected;
+    expect(fallback.revokeObjectURL).toHaveBeenCalledOnce();
+    expect(fallback.instances[0].currentSource).toBe("");
+    expect(fallback.instances[0].onload).toBeNull();
+    expect(fallback.instances[0].onerror).toBeNull();
+  });
+});

--- a/src/lib/images/optimize-images.ts
+++ b/src/lib/images/optimize-images.ts
@@ -2,6 +2,9 @@ const MAX_FILE_BYTES = 5 * 1024 * 1024;
 const MAX_TOTAL_BYTES = 10 * 1024 * 1024;
 const IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
 const CAPACITY_ERROR = "画像を容量上限（1枚5MiB・添付済み画像を含め合計10MiB）以内に最適化できませんでした。画像の枚数を減らすか、別の画像を選択してください。";
+const ANIMATED_IMAGE_ERROR = "アニメーション画像（APNG・Animated WebP）は現在最適化できません。静止画に変換してから選択してください。";
+const PNG_SIGNATURE = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a] as const;
+const MAX_CONTAINER_CHUNKS = 256;
 
 // Each pass applies the same settings to the whole selection. Always redraw
 // from the originals to avoid accumulating JPEG/WebP compression artifacts.
@@ -41,6 +44,75 @@ function throwIfAborted(signal?: AbortSignal) {
   if (signal?.aborted) {
     throw new DOMException("画像の最適化を中止しました", "AbortError");
   }
+}
+
+async function readBytes(file: File, start: number, length: number, signal?: AbortSignal): Promise<Uint8Array> {
+  throwIfAborted(signal);
+  const bytes = new Uint8Array(await file.slice(start, start + length).arrayBuffer());
+  throwIfAborted(signal);
+  return bytes;
+}
+
+function ascii(bytes: Uint8Array, start: number, length: number): string {
+  return String.fromCharCode(...bytes.subarray(start, start + length));
+}
+
+async function isAnimatedPng(file: File, signal?: AbortSignal): Promise<boolean> {
+  const signature = await readBytes(file, 0, 8, signal);
+  if (signature.length !== PNG_SIGNATURE.length || PNG_SIGNATURE.some((value, index) => signature[index] !== value)) {
+    return false;
+  }
+
+  let offset = 8;
+  for (let chunk = 0; chunk < MAX_CONTAINER_CHUNKS && offset + 8 <= file.size; chunk += 1) {
+    const header = await readBytes(file, offset, 8, signal);
+    if (header.length < 8) return false;
+    const length = new DataView(header.buffer, header.byteOffset, header.byteLength).getUint32(0, false);
+    const type = ascii(header, 4, 4);
+    if (type === "acTL") return true;
+    // APNG requires acTL before the first IDAT chunk.
+    if (type === "IDAT" || type === "IEND") return false;
+    const nextOffset = offset + 12 + length;
+    if (!Number.isSafeInteger(nextOffset) || nextOffset <= offset || nextOffset > file.size) return false;
+    offset = nextOffset;
+  }
+  return false;
+}
+
+async function isAnimatedWebp(file: File, signal?: AbortSignal): Promise<boolean> {
+  const riff = await readBytes(file, 0, 12, signal);
+  if (riff.length < 12 || ascii(riff, 0, 4) !== "RIFF" || ascii(riff, 8, 4) !== "WEBP") {
+    return false;
+  }
+
+  let offset = 12;
+  for (let chunk = 0; chunk < MAX_CONTAINER_CHUNKS && offset + 8 <= file.size; chunk += 1) {
+    const header = await readBytes(file, offset, 8, signal);
+    if (header.length < 8) return false;
+    const type = ascii(header, 0, 4);
+    const length = new DataView(header.buffer, header.byteOffset, header.byteLength).getUint32(4, true);
+    if (type === "ANIM" || type === "ANMF") return true;
+    if (type === "VP8X") {
+      if (length < 1) return false;
+      const flags = await readBytes(file, offset + 8, 1, signal);
+      if (flags.length === 1 && (flags[0] & 0x02) !== 0) return true;
+    }
+    if (type === "VP8 " || type === "VP8L") return false;
+    const paddedLength = length + (length % 2);
+    const nextOffset = offset + 8 + paddedLength;
+    if (!Number.isSafeInteger(nextOffset) || nextOffset <= offset || nextOffset > file.size) return false;
+    offset = nextOffset;
+  }
+  return false;
+}
+
+async function assertStillImage(file: File, signal?: AbortSignal): Promise<void> {
+  const animated = file.type === "image/png"
+    ? await isAnimatedPng(file, signal)
+    : file.type === "image/webp"
+      ? await isAnimatedWebp(file, signal)
+      : false;
+  if (animated) throw new Error(ANIMATED_IMAGE_ERROR);
 }
 
 async function decodeImage(file: File, signal?: AbortSignal): Promise<DecodedImage> {
@@ -191,6 +263,9 @@ export async function optimizeImages(
     if (!IMAGE_TYPES.has(file.type)) {
       throw new Error("画像はJPEG・PNG・WebP形式を選択してください。");
     }
+  }
+  for (const file of files) {
+    await assertStillImage(file, options.signal);
   }
   // Callers may reserve capacity for attachments already stored in the report.
   // Options can tighten the limits, but cannot relax the server's limits.

--- a/src/lib/images/optimize-images.ts
+++ b/src/lib/images/optimize-images.ts
@@ -1,0 +1,220 @@
+const MAX_FILE_BYTES = 5 * 1024 * 1024;
+const MAX_TOTAL_BYTES = 10 * 1024 * 1024;
+const IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
+const CAPACITY_ERROR = "画像を容量上限（1枚5MiB・添付済み画像を含め合計10MiB）以内に最適化できませんでした。画像の枚数を減らすか、別の画像を選択してください。";
+
+// Each pass applies the same settings to the whole selection. Always redraw
+// from the originals to avoid accumulating JPEG/WebP compression artifacts.
+const PASSES = [
+  { maxDimension: 2560, quality: 0.82 },
+  { maxDimension: 2560, quality: 0.75 },
+  { maxDimension: 2560, quality: 0.68 },
+  { maxDimension: 2560, quality: 0.62 },
+  { maxDimension: 2048, quality: 0.62 },
+  { maxDimension: 1600, quality: 0.62 },
+] as const;
+
+export type OptimizedImage = {
+  file: File;
+  originalSize: number;
+  optimizedSize: number;
+  originalMimeType: string;
+  optimizedMimeType: string;
+  width: number;
+  height: number;
+};
+
+export type OptimizationOptions = {
+  maxTotalBytes?: number;
+  maxFileBytes?: number;
+  signal?: AbortSignal;
+};
+
+type DecodedImage = {
+  source: CanvasImageSource;
+  width: number;
+  height: number;
+  release: () => void;
+};
+
+function throwIfAborted(signal?: AbortSignal) {
+  if (signal?.aborted) {
+    throw new DOMException("画像の最適化を中止しました", "AbortError");
+  }
+}
+
+async function decodeImage(file: File, signal?: AbortSignal): Promise<DecodedImage> {
+  if (typeof createImageBitmap === "function") {
+    try {
+      const bitmap = await createImageBitmap(file, { imageOrientation: "from-image" });
+      return {
+        source: bitmap,
+        width: bitmap.width,
+        height: bitmap.height,
+        release: () => bitmap.close(),
+      };
+    } catch {
+      // Some Safari versions cannot decode all supported formats/options with
+      // ImageBitmap. HTMLImageElement also applies the image's EXIF orientation.
+      throwIfAborted(signal);
+    }
+  }
+
+  const image = new Image();
+  const url = URL.createObjectURL(file);
+  const release = () => {
+    image.src = "";
+    URL.revokeObjectURL(url);
+  };
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const cleanup = () => {
+        image.onload = null;
+        image.onerror = null;
+        signal?.removeEventListener("abort", onAbort);
+      };
+      const onAbort = () => {
+        cleanup();
+        reject(new DOMException("画像の最適化を中止しました", "AbortError"));
+      };
+      image.onload = () => {
+        cleanup();
+        resolve();
+      };
+      image.onerror = () => {
+        cleanup();
+        reject(new Error(`${file.name}を読み込めませんでした。別の画像を選択してください。`));
+      };
+      signal?.addEventListener("abort", onAbort, { once: true });
+      if (signal?.aborted) {
+        onAbort();
+      } else {
+        image.src = url;
+      }
+    });
+    return { source: image, width: image.naturalWidth, height: image.naturalHeight, release };
+  } catch (error) {
+    release();
+    throw error;
+  }
+}
+
+function outputFilename(filename: string, mimeType: string) {
+  const extension = mimeType === "image/jpeg" ? "jpg" : mimeType.split("/")[1];
+  const dotIndex = filename.lastIndexOf(".");
+  const currentExtension = dotIndex > 0 ? filename.slice(dotIndex + 1).toLowerCase() : "";
+  const hasMatchingExtension = currentExtension === extension || (mimeType === "image/jpeg" && currentExtension === "jpeg");
+  if (hasMatchingExtension && filename.length <= 255) {
+    return filename;
+  }
+  const stem = (dotIndex > 0 ? filename.slice(0, dotIndex) : filename) || "image";
+  const suffix = `.${hasMatchingExtension ? filename.slice(dotIndex + 1) : extension}`;
+  let safeStem = "";
+  // Match the API's 255-character limit without splitting a Unicode pair.
+  for (const character of stem) {
+    if (safeStem.length + character.length > 255 - suffix.length) break;
+    safeStem += character;
+  }
+  return `${safeStem}${suffix}`;
+}
+
+async function optimizeImage(
+  file: File,
+  settings: (typeof PASSES)[number],
+  signal?: AbortSignal,
+): Promise<OptimizedImage> {
+  const decoded = await decodeImage(file, signal);
+  let canvas: HTMLCanvasElement | undefined;
+  try {
+    throwIfAborted(signal);
+    if (!Number.isFinite(decoded.width) || !Number.isFinite(decoded.height) || decoded.width <= 0 || decoded.height <= 0) {
+      throw new Error(`${file.name}の画像サイズを読み取れませんでした。別の画像を選択してください。`);
+    }
+    const scale = Math.min(1, settings.maxDimension / Math.max(decoded.width, decoded.height));
+    const width = Math.max(1, Math.round(decoded.width * scale));
+    const height = Math.max(1, Math.round(decoded.height * scale));
+    canvas = document.createElement("canvas");
+    canvas.width = width;
+    canvas.height = height;
+    const context = canvas.getContext("2d");
+    if (!context) {
+      throw new Error("このブラウザでは画像を最適化できませんでした。別のブラウザでお試しください。");
+    }
+    context.imageSmoothingEnabled = true;
+    context.imageSmoothingQuality = "high";
+    context.drawImage(decoded.source, 0, 0, width, height);
+
+    // PNG/WebP may contain transparency, so never flatten them into JPEG.
+    const requestedMimeType = file.type === "image/jpeg" ? "image/jpeg" : "image/webp";
+    const blob = await new Promise<Blob>((resolve, reject) => {
+      canvas!.toBlob((result) => {
+        // Unsupported encoders fall back to PNG per the Canvas specification.
+        // It is still a new encoding with no source EXIF and preserves alpha.
+        if (!result || !result.size || (result.type !== requestedMimeType && result.type !== "image/png")) {
+          reject(new Error(`${file.name}を最適化できませんでした。別の画像を選択してください。`));
+        } else {
+          resolve(result);
+        }
+      }, requestedMimeType, settings.quality);
+    });
+    throwIfAborted(signal);
+    const optimizedFile = new File([blob], outputFilename(file.name, blob.type), {
+      type: blob.type,
+      lastModified: file.lastModified,
+    });
+    return {
+      file: optimizedFile,
+      originalSize: file.size,
+      optimizedSize: optimizedFile.size,
+      originalMimeType: file.type,
+      optimizedMimeType: optimizedFile.type,
+      width,
+      height,
+    };
+  } finally {
+    // Release each decoded image and canvas before starting another image.
+    if (canvas) {
+      canvas.width = 0;
+      canvas.height = 0;
+    }
+    decoded.release();
+  }
+}
+
+export async function optimizeImages(
+  files: readonly File[],
+  options: OptimizationOptions = {},
+): Promise<OptimizedImage[]> {
+  throwIfAborted(options.signal);
+  if (!files.length) return [];
+  for (const file of files) {
+    if (!IMAGE_TYPES.has(file.type)) {
+      throw new Error("画像はJPEG・PNG・WebP形式を選択してください。");
+    }
+  }
+  // Callers may reserve capacity for attachments already stored in the report.
+  // Options can tighten the limits, but cannot relax the server's limits.
+  const maxFileBytes = Math.min(options.maxFileBytes ?? MAX_FILE_BYTES, MAX_FILE_BYTES);
+  const maxTotalBytes = Math.min(options.maxTotalBytes ?? MAX_TOTAL_BYTES, MAX_TOTAL_BYTES);
+  if (!Number.isFinite(maxFileBytes) || !Number.isFinite(maxTotalBytes) || maxFileBytes <= 0 || maxTotalBytes <= 0) {
+    throw new Error(CAPACITY_ERROR);
+  }
+
+  const results: OptimizedImage[] = [];
+  for (const settings of PASSES) {
+    for (const [index, file] of files.entries()) {
+      // Give input/paint events time between images without parallel decodes.
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      throwIfAborted(options.signal);
+      const candidate = await optimizeImage(file, settings, options.signal);
+      if (!results[index] || candidate.optimizedSize < results[index].optimizedSize) {
+        results[index] = candidate;
+      }
+    }
+    const totalBytes = results.reduce((total, result) => total + result.optimizedSize, 0);
+    if (totalBytes <= maxTotalBytes && results.every((result) => result.optimizedSize <= maxFileBytes)) {
+      return results;
+    }
+  }
+  throw new Error(CAPACITY_ERROR);
+}

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { reportInputSchema } from "@/lib/validation";
+import { reportInputSchema, uploadRequestSchema } from "@/lib/validation";
 
 const valid = {
   reportDate: "2026-08-19",
@@ -37,5 +37,26 @@ describe("reportInputSchema", () => {
   it("rejects a future JST date", () => {
     const result = reportInputSchema.safeParse({ ...valid, reportDate: "2999-01-01" });
     expect(result.success).toBe(false);
+  });
+
+  it("keeps the 5 MiB per-image and 10 MiB report limits on the server", () => {
+    const attachment = {
+      storagePath: "owner/photo.jpg",
+      filename: "photo.jpg",
+      mimeType: "image/jpeg",
+      sizeBytes: 5 * 1024 * 1024,
+    };
+    expect(uploadRequestSchema.safeParse(attachment).success).toBe(true);
+    expect(uploadRequestSchema.safeParse({ ...attachment, sizeBytes: attachment.sizeBytes + 1 }).success).toBe(false);
+    expect(reportInputSchema.safeParse({ ...valid, attachments: [attachment, attachment] }).success).toBe(true);
+    expect(reportInputSchema.safeParse({ ...valid, attachments: [{ ...attachment, sizeBytes: attachment.sizeBytes + 1 }] }).success).toBe(false);
+    expect(reportInputSchema.safeParse({
+      ...valid,
+      attachments: [attachment, attachment, { ...attachment, sizeBytes: 1 }],
+    }).success).toBe(false);
+  });
+
+  it("continues to reject unsupported image formats on the server", () => {
+    expect(uploadRequestSchema.safeParse({ filename: "photo.heic", mimeType: "image/heic", sizeBytes: 1024 }).success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

日報への画像添付時に、ブラウザ側で画像を自動最適化してからSigned Uploadするようにしました。長辺リサイズ、再エンコード、メタデータ除去、1枚5MiB・日報合計10MiBの維持を行い、元のFileは変更しません。

## Compression Strategy

- 初期設定は長辺2560px、quality 0.82です。
- 合計または1枚の上限を超える場合は、全画像へquality 0.75 / 0.68 / 0.62を均等に適用します。
- 必要な場合は長辺を2048px、1600pxまで段階的に縮小します。
- JPEGはJPEG、PNG/WebPはWebPを優先し、WebP encoderが利用できない場合はPNGへフォールバックします。
- 画像は逐次処理し、処理中は保存・削除・追加選択を無効化します。
- APNG / Animated WebPはCanvas再エンコードでアニメーションを失わないよう、最適化前に検出して明示的に拒否します。

## Browser Compatibility

- Chromium: 大画像、透過、EXIF Orientation、失敗復帰、既存添付を含む残容量をE2E検証。
- Mobile Chromium: 同じ主要画像ケースを検証。
- WebKit: 画像生成 → 最適化 → Demo Signed Upload → attachment反映まで実ブラウザE2Eで検証。
- PlaywrightのoriginとDemo Signed Uploadのoriginを`127.0.0.1:3000`へ統一し、CSP `connect-src 'self'`下でも実際のアップロード経路を検証します。

## Security / Data Integrity

- サーバー側の5MiB / 10MiB validationを維持しました。
- Signed Upload、Private Storage、owner単位のStorage Pathを変更していません。
- Canvas再エンコードにより、アップロード前に元画像のEXIFを除去します。
- APNGは`acTL`、Animated WebPは`VP8X` animation flag / `ANIM` / `ANMF`をコンテナから検出し、silentな静止画化を防止します。
- animated判定はdecode前に実行します。

## Performance

画像をPromise.allで一括decodeせず、1枚ずつdecode・encode・解放します。入力した元Fileは変更しません。

## Latest CI

- `npm ci` ✅
- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm test` ✅ — 189 passed / 5 skipped
- `npm run build` ✅
- `npm run test:e2e` ✅ — 54 passed / 15 skipped
- Vercel `hanabi-log` ✅
- Vercel `hanabi-log-zlnq` ✅

## Review fixes

- CSPとPlaywrightの`localhost` / `127.0.0.1` origin不一致による画像upload E2E失敗を修正。
- APNG / Animated WebPのsilent frame lossを防止。
- WebKitで画像最適化の実upload経路を追加検証。
