### PR TITLE
fix: prevent Slack ingestion poison queues on current main

### DIFF
--- a/docs/slack-ingestion-retry-rollout.md
+++ b/docs/slack-ingestion-retry-rollout.md
@@ -1,0 +1,27 @@
+# Slack ingestion retry / dead-letter rollout
+
+Slackの取り込みqueueへretry / dead-letter stateを追加する変更は、application deployとDB migrationの順序が逆転してもWebhook処理を壊さないよう段階導入します。
+
+## Mode
+
+`SLACK_INGESTION_RETRY_MODE`は次の2値です。
+
+- `off`（未設定時のdefault）: 既存schemaだけを使う。`attempts` / `available_at` / `last_error` / `dead_at`列へアクセスしない。
+- `enforce`: retry / backoff / dead-letter処理を有効化する。
+
+不明な値はconfiguration errorにします。
+
+## Safe deployment order
+
+1. `SLACK_INGESTION_RETRY_MODE`を未設定または`off`のままapplication codeをdeployする。
+2. 本番DBへ`supabase/migrations/202609070007_slack_incoming_retry_state.sql`を適用する。
+3. 両tableに`attempts`、`available_at`、`last_error`、`dead_at`が存在することを確認する。
+4. `SLACK_INGESTION_RETRY_MODE=enforce`を設定してredeployする。
+5. 新しいSlack eventが通常処理されることを確認する。
+6. 一時失敗がbackoffされ、恒久失敗がdead-letter化されることを管理query/health UIで確認する。
+
+Migration適用前に`enforce`へ切り替えてはいけません。
+
+## Rollback
+
+Application側で問題が起きた場合は、まず`SLACK_INGESTION_RETRY_MODE=off`へ戻してredeployします。追加DB列は後方互換なので、即座にdropする必要はありません。

--- a/src/app/api/integrations/slack/events/route.ts
+++ b/src/app/api/integrations/slack/events/route.ts
@@ -4,7 +4,6 @@ import { getDatabase } from "@/server/db/client";
 import { incomingSlackMessage, incomingSlackReaction, verifySlackSignature } from "@/server/integrations/slack-incoming";
 import { processIncomingSlackReports } from "@/server/integrations/slack-incoming-store";
 import { processPendingJobs } from "@/server/integrations/outbox";
-
 import { processLikeNotifications } from "@/server/integrations/like-notifications";
 
 export async function POST(request: Request): Promise<Response> {
@@ -24,7 +23,13 @@ export async function POST(request: Request): Promise<Response> {
       await sql`insert into slack_incoming_reports (channel_id, message_ts, user_id, body, event_ts)
         values (${message.channel}, ${message.ts}, ${message.user}, ${message.text}, ${message.eventTs})
         on conflict (channel_id, message_ts) do update set
-          body = excluded.body, event_ts = excluded.event_ts, processed_at = null
+          body = excluded.body,
+          event_ts = excluded.event_ts,
+          processed_at = null,
+          attempts = 0,
+          available_at = now(),
+          last_error = null,
+          dead_at = null
         where slack_incoming_reports.event_ts < excluded.event_ts
           and slack_incoming_reports.user_id = excluded.user_id`;
     }
@@ -32,7 +37,13 @@ export async function POST(request: Request): Promise<Response> {
       await sql`insert into slack_report_reactions (channel_id, message_ts, user_id, reaction, active, event_ts)
         values (${reaction.item.channel}, ${reaction.item.ts}, ${reaction.user}, ${reaction.reaction}, ${reaction.type === "reaction_added"}, ${reaction.event_ts})
         on conflict (channel_id, message_ts, user_id, reaction) do update set
-          active = excluded.active, event_ts = excluded.event_ts, processed_at = null
+          active = excluded.active,
+          event_ts = excluded.event_ts,
+          processed_at = null,
+          attempts = 0,
+          available_at = now(),
+          last_error = null,
+          dead_at = null
         where slack_report_reactions.event_ts < excluded.event_ts`;
     }
     after(async () => {

--- a/src/app/api/integrations/slack/events/route.ts
+++ b/src/app/api/integrations/slack/events/route.ts
@@ -3,6 +3,7 @@ import { env, isDemoMode } from "@/server/env";
 import { getDatabase } from "@/server/db/client";
 import { incomingSlackMessage, incomingSlackReaction, verifySlackSignature } from "@/server/integrations/slack-incoming";
 import { processIncomingSlackReports } from "@/server/integrations/slack-incoming-store";
+import { slackIngestionRetryEnabled } from "@/server/integrations/slack-incoming-retry-mode";
 import { processPendingJobs } from "@/server/integrations/outbox";
 import { processLikeNotifications } from "@/server/integrations/like-notifications";
 
@@ -19,32 +20,50 @@ export async function POST(request: Request): Promise<Response> {
   const reaction = payload.type === "event_callback" ? incomingSlackReaction(payload.event, env.SLACK_CHANNEL_ID) : null;
   if (message || reaction) {
     const sql = getDatabase();
+    const retryEnabled = slackIngestionRetryEnabled();
     if (message) {
-      await sql`insert into slack_incoming_reports (channel_id, message_ts, user_id, body, event_ts)
-        values (${message.channel}, ${message.ts}, ${message.user}, ${message.text}, ${message.eventTs})
-        on conflict (channel_id, message_ts) do update set
-          body = excluded.body,
-          event_ts = excluded.event_ts,
-          processed_at = null,
-          attempts = 0,
-          available_at = now(),
-          last_error = null,
-          dead_at = null
-        where slack_incoming_reports.event_ts < excluded.event_ts
-          and slack_incoming_reports.user_id = excluded.user_id`;
+      if (retryEnabled) {
+        await sql`insert into slack_incoming_reports (channel_id, message_ts, user_id, body, event_ts)
+          values (${message.channel}, ${message.ts}, ${message.user}, ${message.text}, ${message.eventTs})
+          on conflict (channel_id, message_ts) do update set
+            body = excluded.body,
+            event_ts = excluded.event_ts,
+            processed_at = null,
+            attempts = 0,
+            available_at = now(),
+            last_error = null,
+            dead_at = null
+          where slack_incoming_reports.event_ts < excluded.event_ts
+            and slack_incoming_reports.user_id = excluded.user_id`;
+      } else {
+        await sql`insert into slack_incoming_reports (channel_id, message_ts, user_id, body, event_ts)
+          values (${message.channel}, ${message.ts}, ${message.user}, ${message.text}, ${message.eventTs})
+          on conflict (channel_id, message_ts) do update set
+            body = excluded.body, event_ts = excluded.event_ts, processed_at = null
+          where slack_incoming_reports.event_ts < excluded.event_ts
+            and slack_incoming_reports.user_id = excluded.user_id`;
+      }
     }
     if (reaction) {
-      await sql`insert into slack_report_reactions (channel_id, message_ts, user_id, reaction, active, event_ts)
-        values (${reaction.item.channel}, ${reaction.item.ts}, ${reaction.user}, ${reaction.reaction}, ${reaction.type === "reaction_added"}, ${reaction.event_ts})
-        on conflict (channel_id, message_ts, user_id, reaction) do update set
-          active = excluded.active,
-          event_ts = excluded.event_ts,
-          processed_at = null,
-          attempts = 0,
-          available_at = now(),
-          last_error = null,
-          dead_at = null
-        where slack_report_reactions.event_ts < excluded.event_ts`;
+      if (retryEnabled) {
+        await sql`insert into slack_report_reactions (channel_id, message_ts, user_id, reaction, active, event_ts)
+          values (${reaction.item.channel}, ${reaction.item.ts}, ${reaction.user}, ${reaction.reaction}, ${reaction.type === "reaction_added"}, ${reaction.event_ts})
+          on conflict (channel_id, message_ts, user_id, reaction) do update set
+            active = excluded.active,
+            event_ts = excluded.event_ts,
+            processed_at = null,
+            attempts = 0,
+            available_at = now(),
+            last_error = null,
+            dead_at = null
+          where slack_report_reactions.event_ts < excluded.event_ts`;
+      } else {
+        await sql`insert into slack_report_reactions (channel_id, message_ts, user_id, reaction, active, event_ts)
+          values (${reaction.item.channel}, ${reaction.item.ts}, ${reaction.user}, ${reaction.reaction}, ${reaction.type === "reaction_added"}, ${reaction.event_ts})
+          on conflict (channel_id, message_ts, user_id, reaction) do update set
+            active = excluded.active, event_ts = excluded.event_ts, processed_at = null
+          where slack_report_reactions.event_ts < excluded.event_ts`;
+      }
     }
     after(async () => {
       try {

--- a/src/server/integrations/slack-incoming-retry-mode.test.ts
+++ b/src/server/integrations/slack-incoming-retry-mode.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import {
+  configuredSlackIngestionRetryMode,
+  slackIngestionRetryEnabled,
+} from "@/server/integrations/slack-incoming-retry-mode";
+
+describe("Slack ingestion retry rollout", () => {
+  it("stays off until production migration rollout is explicitly activated", () => {
+    expect(configuredSlackIngestionRetryMode({})).toBe("off");
+    expect(slackIngestionRetryEnabled({ SLACK_INGESTION_RETRY_MODE: "off" })).toBe(false);
+    expect(slackIngestionRetryEnabled({ SLACK_INGESTION_RETRY_MODE: "enforce" })).toBe(true);
+  });
+
+  it("rejects unknown rollout values instead of silently changing behavior", () => {
+    expect(() => configuredSlackIngestionRetryMode({ SLACK_INGESTION_RETRY_MODE: "enabled" })).toThrow(
+      "SLACK_INGESTION_RETRY_MODE must be either 'off' or 'enforce'",
+    );
+  });
+});

--- a/src/server/integrations/slack-incoming-retry-mode.ts
+++ b/src/server/integrations/slack-incoming-retry-mode.ts
@@ -1,0 +1,18 @@
+export type SlackIngestionRetryMode = "off" | "enforce";
+
+type Environment = Record<string, string | undefined>;
+
+export function configuredSlackIngestionRetryMode(
+  environment: Environment = process.env,
+): SlackIngestionRetryMode {
+  const raw = environment.SLACK_INGESTION_RETRY_MODE?.trim().toLowerCase();
+  if (!raw || raw === "off") return "off";
+  if (raw === "enforce") return "enforce";
+  throw new Error("SLACK_INGESTION_RETRY_MODE must be either 'off' or 'enforce'");
+}
+
+export function slackIngestionRetryEnabled(
+  environment: Environment = process.env,
+): boolean {
+  return configuredSlackIngestionRetryMode(environment) === "enforce";
+}

--- a/src/server/integrations/slack-incoming-store.ts
+++ b/src/server/integrations/slack-incoming-store.ts
@@ -5,18 +5,30 @@ import { env, isDemoMode } from "@/server/env";
 import { resolveReportTitle } from "@/lib/report-title";
 import { toHanabiReportDate } from "@/lib/timezone";
 
+const MAX_INGESTION_ATTEMPTS = 5;
+
 export async function processIncomingSlackReports(): Promise<void> {
   if (isDemoMode || !env.SLACK_TEAM_ID || !env.SLACK_BOT_TOKEN) return;
   const sql = getDatabase();
   const client = new WebClient(env.SLACK_BOT_TOKEN, { retryConfig: { retries: 0 }, timeout: 5000 });
-  const pending = await sql`select * from slack_incoming_reports where processed_at is null order by created_at limit 20`;
+  const pending = await sql`select * from slack_incoming_reports
+    where processed_at is null and dead_at is null and available_at <= now()
+    order by available_at, created_at limit 20`;
   for (const candidate of pending) {
     try {
       const existing = await sql`select id from members where slack_team_id = ${env.SLACK_TEAM_ID} and slack_user_id = ${candidate.user_id}`;
       const profile = existing.length ? undefined : (await client.users.info({ user: candidate.user_id })).user;
-      if (!existing.length && (!profile || profile.is_bot || profile.deleted)) continue;
+      if (!existing.length && (!profile || profile.is_bot || profile.deleted)) {
+        await sql`update slack_incoming_reports set dead_at = now(), last_error = 'slack_user_unavailable'
+          where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts}
+            and processed_at is null and dead_at is null`;
+        continue;
+      }
       await sql.begin(async (tx) => {
-        const [message] = await tx`select * from slack_incoming_reports where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts} and processed_at is null for update skip locked`;
+        const [message] = await tx`select * from slack_incoming_reports
+          where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts}
+            and processed_at is null and dead_at is null and available_at <= now()
+          for update skip locked`;
         if (!message) return;
         const body = message.body.replaceAll("&lt;", "<").replaceAll("&gt;", ">").replaceAll("&amp;", "&");
         if (message.imported) {
@@ -32,7 +44,8 @@ export async function processIncomingSlackReports(): Promise<void> {
               await tx`update integration_bindings set notion_status = 'pending', notion_last_error = null where report_id = ${report.id}`;
             }
           }
-          await tx`update slack_incoming_reports set processed_at = now() where channel_id = ${message.channel_id} and message_ts = ${message.message_ts}`;
+          await tx`update slack_incoming_reports set processed_at = now(), last_error = null
+            where channel_id = ${message.channel_id} and message_ts = ${message.message_ts}`;
           return;
         }
         const admin = (env.ADMIN_SLACK_USER_IDS ?? "").split(",").map(value => value.trim()).includes(candidate.user_id);
@@ -56,16 +69,29 @@ export async function processIncomingSlackReports(): Promise<void> {
           await tx`insert into outbox_jobs (report_id, target, action, report_version, dedupe_key)
             values (${report.id}, 'notion', 'publish', 1, ${`${report.id}:notion:publish:1`})`;
         }
-        await tx`update slack_incoming_reports set processed_at = now(), imported = true, report_id = ${report.id}
+        await tx`update slack_incoming_reports set processed_at = now(), imported = true, report_id = ${report.id}, last_error = null
           where channel_id = ${message.channel_id} and message_ts = ${message.message_ts}`;
       });
     } catch {
-      console.error("Slack report import failed; retained for retry", { channel: candidate.channel_id, ts: candidate.message_ts });
+      await sql`update slack_incoming_reports set
+          attempts = attempts + 1,
+          dead_at = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then now() else dead_at end,
+          available_at = case
+            when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then available_at
+            when attempts = 0 then now() + interval '5 seconds'
+            when attempts = 1 then now() + interval '15 seconds'
+            when attempts = 2 then now() + interval '30 seconds'
+            when attempts = 3 then now() + interval '1 minute'
+            else now() + interval '5 minutes'
+          end,
+          last_error = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then 'retry_exhausted' else 'import_failed' end
+        where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts}
+          and processed_at is null and dead_at is null`;
+      console.error("Slack report import failed; scheduled retry", { channel: candidate.channel_id, ts: candidate.message_ts });
     }
   }
   await processSlackReactions(client);
 }
-
 
 async function processSlackReactions(client: WebClient): Promise<void> {
   const sql = getDatabase();
@@ -73,22 +99,30 @@ async function processSlackReactions(client: WebClient): Promise<void> {
   const pending = await sql`select distinct reaction.channel_id, reaction.message_ts, reaction.user_id, binding.report_id
     from slack_report_reactions reaction
     join integration_bindings binding on binding.slack_channel_id = reaction.channel_id and binding.slack_message_ts = reaction.message_ts
-    where reaction.processed_at is null limit 20`;
+    where reaction.processed_at is null and reaction.dead_at is null and reaction.available_at <= now()
+    limit 20`;
   for (const reaction of pending) {
     try {
       const existing = await sql`select id from members where slack_team_id = ${env.SLACK_TEAM_ID!} and slack_user_id = ${reaction.user_id}`;
       const profile = existing.length ? undefined : (await client.users.info({ user: reaction.user_id })).user;
       if (!existing.length && (!profile || profile.is_bot || profile.deleted)) {
-        await sql`update slack_report_reactions set processed_at = now()
-          where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts} and user_id = ${reaction.user_id}`;
+        await sql`update slack_report_reactions set dead_at = now(), last_error = 'slack_user_unavailable'
+          where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
+            and user_id = ${reaction.user_id} and processed_at is null and dead_at is null`;
         continue;
       }
       await sql.begin(async (tx) => {
         // Web likes use the same report lock, keeping concurrent toggles consistent.
         const report = await tx`select id from reports where id = ${reaction.report_id} for update`;
-        if (!report.length) return;
+        if (!report.length) {
+          await tx`update slack_report_reactions set dead_at = now(), last_error = 'report_missing'
+            where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
+              and user_id = ${reaction.user_id} and processed_at is null and dead_at is null`;
+          return;
+        }
         const states = await tx`select reaction, active from slack_report_reactions
           where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts} and user_id = ${reaction.user_id}
+            and processed_at is null and dead_at is null
           order by reaction for update`;
         if (!existing.length) {
           const admin = (env.ADMIN_SLACK_USER_IDS ?? "").split(",").map(value => value.trim()).includes(reaction.user_id);
@@ -107,13 +141,27 @@ async function processSlackReactions(client: WebClient): Promise<void> {
         }
         // Mark only the rows locked above; newly arriving emojis remain pending.
         for (const state of states) {
-          await tx`update slack_report_reactions set processed_at = now()
+          await tx`update slack_report_reactions set processed_at = now(), last_error = null
             where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
               and user_id = ${reaction.user_id} and reaction = ${state.reaction}`;
         }
       });
     } catch {
-      console.error("Slack reaction sync failed; retained for retry", { channel: reaction.channel_id, ts: reaction.message_ts });
+      await sql`update slack_report_reactions set
+          attempts = attempts + 1,
+          dead_at = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then now() else dead_at end,
+          available_at = case
+            when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then available_at
+            when attempts = 0 then now() + interval '5 seconds'
+            when attempts = 1 then now() + interval '15 seconds'
+            when attempts = 2 then now() + interval '30 seconds'
+            when attempts = 3 then now() + interval '1 minute'
+            else now() + interval '5 minutes'
+          end,
+          last_error = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then 'retry_exhausted' else 'sync_failed' end
+        where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
+          and user_id = ${reaction.user_id} and processed_at is null and dead_at is null`;
+      console.error("Slack reaction sync failed; scheduled retry", { channel: reaction.channel_id, ts: reaction.message_ts });
     }
   }
 }

--- a/src/server/integrations/slack-incoming-store.ts
+++ b/src/server/integrations/slack-incoming-store.ts
@@ -4,32 +4,46 @@ import { getDatabase } from "@/server/db/client";
 import { env, isDemoMode } from "@/server/env";
 import { resolveReportTitle } from "@/lib/report-title";
 import { toHanabiReportDate } from "@/lib/timezone";
+import { slackIngestionRetryEnabled } from "@/server/integrations/slack-incoming-retry-mode";
 
 const MAX_INGESTION_ATTEMPTS = 5;
 
 export async function processIncomingSlackReports(): Promise<void> {
   if (isDemoMode || !env.SLACK_TEAM_ID || !env.SLACK_BOT_TOKEN) return;
   const sql = getDatabase();
+  const retryEnabled = slackIngestionRetryEnabled();
   const client = new WebClient(env.SLACK_BOT_TOKEN, { retryConfig: { retries: 0 }, timeout: 5000 });
-  const pending = await sql`select * from slack_incoming_reports
-    where processed_at is null and dead_at is null and available_at <= now()
-    order by available_at, created_at limit 20`;
+  const pending = retryEnabled
+    ? await sql`select * from slack_incoming_reports
+        where processed_at is null and dead_at is null and available_at <= now()
+        order by available_at, created_at limit 20`
+    : await sql`select * from slack_incoming_reports where processed_at is null order by created_at limit 20`;
+
   for (const candidate of pending) {
     try {
       const existing = await sql`select id from members where slack_team_id = ${env.SLACK_TEAM_ID} and slack_user_id = ${candidate.user_id}`;
       const profile = existing.length ? undefined : (await client.users.info({ user: candidate.user_id })).user;
       if (!existing.length && (!profile || profile.is_bot || profile.deleted)) {
-        await sql`update slack_incoming_reports set dead_at = now(), last_error = 'slack_user_unavailable'
-          where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts}
-            and processed_at is null and dead_at is null`;
+        if (retryEnabled) {
+          await sql`update slack_incoming_reports set dead_at = now(), last_error = 'slack_user_unavailable'
+            where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts}
+              and processed_at is null and dead_at is null`;
+        }
         continue;
       }
+
       await sql.begin(async (tx) => {
-        const [message] = await tx`select * from slack_incoming_reports
-          where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts}
-            and processed_at is null and dead_at is null and available_at <= now()
-          for update skip locked`;
+        const [message] = retryEnabled
+          ? await tx`select * from slack_incoming_reports
+              where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts}
+                and processed_at is null and dead_at is null and available_at <= now()
+              for update skip locked`
+          : await tx`select * from slack_incoming_reports
+              where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts}
+                and processed_at is null
+              for update skip locked`;
         if (!message) return;
+
         const body = message.body.replaceAll("&lt;", "<").replaceAll("&gt;", ">").replaceAll("&amp;", "&");
         if (message.imported) {
           if (message.report_id) {
@@ -44,10 +58,16 @@ export async function processIncomingSlackReports(): Promise<void> {
               await tx`update integration_bindings set notion_status = 'pending', notion_last_error = null where report_id = ${report.id}`;
             }
           }
-          await tx`update slack_incoming_reports set processed_at = now(), last_error = null
-            where channel_id = ${message.channel_id} and message_ts = ${message.message_ts}`;
+          if (retryEnabled) {
+            await tx`update slack_incoming_reports set processed_at = now(), last_error = null
+              where channel_id = ${message.channel_id} and message_ts = ${message.message_ts}`;
+          } else {
+            await tx`update slack_incoming_reports set processed_at = now()
+              where channel_id = ${message.channel_id} and message_ts = ${message.message_ts}`;
+          }
           return;
         }
+
         const admin = (env.ADMIN_SLACK_USER_IDS ?? "").split(",").map(value => value.trim()).includes(candidate.user_id);
         if (!existing.length) {
           await tx`insert into members (slack_team_id, slack_user_id, display_name, avatar_url, role)
@@ -69,61 +89,86 @@ export async function processIncomingSlackReports(): Promise<void> {
           await tx`insert into outbox_jobs (report_id, target, action, report_version, dedupe_key)
             values (${report.id}, 'notion', 'publish', 1, ${`${report.id}:notion:publish:1`})`;
         }
-        await tx`update slack_incoming_reports set processed_at = now(), imported = true, report_id = ${report.id}, last_error = null
-          where channel_id = ${message.channel_id} and message_ts = ${message.message_ts}`;
+        if (retryEnabled) {
+          await tx`update slack_incoming_reports set processed_at = now(), imported = true, report_id = ${report.id}, last_error = null
+            where channel_id = ${message.channel_id} and message_ts = ${message.message_ts}`;
+        } else {
+          await tx`update slack_incoming_reports set processed_at = now(), imported = true, report_id = ${report.id}
+            where channel_id = ${message.channel_id} and message_ts = ${message.message_ts}`;
+        }
       });
     } catch {
-      await sql`update slack_incoming_reports set
-          attempts = attempts + 1,
-          dead_at = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then now() else dead_at end,
-          available_at = case
-            when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then available_at
-            when attempts = 0 then now() + interval '5 seconds'
-            when attempts = 1 then now() + interval '15 seconds'
-            when attempts = 2 then now() + interval '30 seconds'
-            when attempts = 3 then now() + interval '1 minute'
-            else now() + interval '5 minutes'
-          end,
-          last_error = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then 'retry_exhausted' else 'import_failed' end
-        where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts}
-          and processed_at is null and dead_at is null`;
-      console.error("Slack report import failed; scheduled retry", { channel: candidate.channel_id, ts: candidate.message_ts });
+      if (retryEnabled) {
+        await sql`update slack_incoming_reports set
+            attempts = attempts + 1,
+            dead_at = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then now() else dead_at end,
+            available_at = case
+              when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then available_at
+              when attempts = 0 then now() + interval '5 seconds'
+              when attempts = 1 then now() + interval '15 seconds'
+              when attempts = 2 then now() + interval '30 seconds'
+              when attempts = 3 then now() + interval '1 minute'
+              else now() + interval '5 minutes'
+            end,
+            last_error = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then 'retry_exhausted' else 'import_failed' end
+          where channel_id = ${candidate.channel_id} and message_ts = ${candidate.message_ts}
+            and processed_at is null and dead_at is null`;
+        console.error("Slack report import failed; scheduled retry", { channel: candidate.channel_id, ts: candidate.message_ts });
+      } else {
+        console.error("Slack report import failed; retained for retry", { channel: candidate.channel_id, ts: candidate.message_ts });
+      }
     }
   }
-  await processSlackReactions(client);
+  await processSlackReactions(client, retryEnabled);
 }
 
-async function processSlackReactions(client: WebClient): Promise<void> {
+async function processSlackReactions(client: WebClient, retryEnabled: boolean): Promise<void> {
   const sql = getDatabase();
-  // Join the binding so unrelated channel chatter and replies are never counted.
-  const pending = await sql`select distinct reaction.channel_id, reaction.message_ts, reaction.user_id, binding.report_id
-    from slack_report_reactions reaction
-    join integration_bindings binding on binding.slack_channel_id = reaction.channel_id and binding.slack_message_ts = reaction.message_ts
-    where reaction.processed_at is null and reaction.dead_at is null and reaction.available_at <= now()
-    limit 20`;
+  const pending = retryEnabled
+    ? await sql`select distinct reaction.channel_id, reaction.message_ts, reaction.user_id, binding.report_id
+        from slack_report_reactions reaction
+        join integration_bindings binding on binding.slack_channel_id = reaction.channel_id and binding.slack_message_ts = reaction.message_ts
+        where reaction.processed_at is null and reaction.dead_at is null and reaction.available_at <= now()
+        limit 20`
+    : await sql`select distinct reaction.channel_id, reaction.message_ts, reaction.user_id, binding.report_id
+        from slack_report_reactions reaction
+        join integration_bindings binding on binding.slack_channel_id = reaction.channel_id and binding.slack_message_ts = reaction.message_ts
+        where reaction.processed_at is null limit 20`;
+
   for (const reaction of pending) {
     try {
       const existing = await sql`select id from members where slack_team_id = ${env.SLACK_TEAM_ID!} and slack_user_id = ${reaction.user_id}`;
       const profile = existing.length ? undefined : (await client.users.info({ user: reaction.user_id })).user;
       if (!existing.length && (!profile || profile.is_bot || profile.deleted)) {
-        await sql`update slack_report_reactions set dead_at = now(), last_error = 'slack_user_unavailable'
-          where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
-            and user_id = ${reaction.user_id} and processed_at is null and dead_at is null`;
-        continue;
-      }
-      await sql.begin(async (tx) => {
-        // Web likes use the same report lock, keeping concurrent toggles consistent.
-        const report = await tx`select id from reports where id = ${reaction.report_id} for update`;
-        if (!report.length) {
-          await tx`update slack_report_reactions set dead_at = now(), last_error = 'report_missing'
+        if (retryEnabled) {
+          await sql`update slack_report_reactions set dead_at = now(), last_error = 'slack_user_unavailable'
             where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
               and user_id = ${reaction.user_id} and processed_at is null and dead_at is null`;
+        } else {
+          await sql`update slack_report_reactions set processed_at = now()
+            where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts} and user_id = ${reaction.user_id}`;
+        }
+        continue;
+      }
+
+      await sql.begin(async (tx) => {
+        const report = await tx`select id from reports where id = ${reaction.report_id} for update`;
+        if (!report.length) {
+          if (retryEnabled) {
+            await tx`update slack_report_reactions set dead_at = now(), last_error = 'report_missing'
+              where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
+                and user_id = ${reaction.user_id} and processed_at is null and dead_at is null`;
+          }
           return;
         }
-        const states = await tx`select reaction, active from slack_report_reactions
-          where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts} and user_id = ${reaction.user_id}
-            and processed_at is null and dead_at is null
-          order by reaction for update`;
+        const states = retryEnabled
+          ? await tx`select reaction, active from slack_report_reactions
+              where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts} and user_id = ${reaction.user_id}
+                and processed_at is null and dead_at is null
+              order by reaction for update`
+          : await tx`select reaction, active from slack_report_reactions
+              where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts} and user_id = ${reaction.user_id}
+              order by reaction for update`;
         if (!existing.length) {
           const admin = (env.ADMIN_SLACK_USER_IDS ?? "").split(",").map(value => value.trim()).includes(reaction.user_id);
           await tx`insert into members (slack_team_id, slack_user_id, display_name, avatar_url, role)
@@ -139,29 +184,38 @@ async function processSlackReactions(client: WebClient): Promise<void> {
           await tx`update report_likes set slack_liked = false where report_id = ${reaction.report_id} and member_id = ${member.id}`;
           await tx`delete from report_likes where report_id = ${reaction.report_id} and member_id = ${member.id} and not web_liked`;
         }
-        // Mark only the rows locked above; newly arriving emojis remain pending.
         for (const state of states) {
-          await tx`update slack_report_reactions set processed_at = now(), last_error = null
-            where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
-              and user_id = ${reaction.user_id} and reaction = ${state.reaction}`;
+          if (retryEnabled) {
+            await tx`update slack_report_reactions set processed_at = now(), last_error = null
+              where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
+                and user_id = ${reaction.user_id} and reaction = ${state.reaction}`;
+          } else {
+            await tx`update slack_report_reactions set processed_at = now()
+              where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
+                and user_id = ${reaction.user_id} and reaction = ${state.reaction}`;
+          }
         }
       });
     } catch {
-      await sql`update slack_report_reactions set
-          attempts = attempts + 1,
-          dead_at = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then now() else dead_at end,
-          available_at = case
-            when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then available_at
-            when attempts = 0 then now() + interval '5 seconds'
-            when attempts = 1 then now() + interval '15 seconds'
-            when attempts = 2 then now() + interval '30 seconds'
-            when attempts = 3 then now() + interval '1 minute'
-            else now() + interval '5 minutes'
-          end,
-          last_error = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then 'retry_exhausted' else 'sync_failed' end
-        where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
-          and user_id = ${reaction.user_id} and processed_at is null and dead_at is null`;
-      console.error("Slack reaction sync failed; scheduled retry", { channel: reaction.channel_id, ts: reaction.message_ts });
+      if (retryEnabled) {
+        await sql`update slack_report_reactions set
+            attempts = attempts + 1,
+            dead_at = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then now() else dead_at end,
+            available_at = case
+              when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then available_at
+              when attempts = 0 then now() + interval '5 seconds'
+              when attempts = 1 then now() + interval '15 seconds'
+              when attempts = 2 then now() + interval '30 seconds'
+              when attempts = 3 then now() + interval '1 minute'
+              else now() + interval '5 minutes'
+            end,
+            last_error = case when attempts + 1 >= ${MAX_INGESTION_ATTEMPTS} then 'retry_exhausted' else 'sync_failed' end
+          where channel_id = ${reaction.channel_id} and message_ts = ${reaction.message_ts}
+            and user_id = ${reaction.user_id} and processed_at is null and dead_at is null`;
+        console.error("Slack reaction sync failed; scheduled retry", { channel: reaction.channel_id, ts: reaction.message_ts });
+      } else {
+        console.error("Slack reaction sync failed; retained for retry", { channel: reaction.channel_id, ts: reaction.message_ts });
+      }
     }
   }
 }

--- a/supabase/migrations/202609070007_slack_incoming_retry_state.sql
+++ b/supabase/migrations/202609070007_slack_incoming_retry_state.sql
@@ -1,0 +1,20 @@
+-- Retry/dead-letter state for Slack ingestion so poison events cannot block later work.
+-- This uses 0007 because 0002-0005 are already occupied on current main and
+-- the open API rate-limit rollout reserves 0006.
+alter table slack_incoming_reports add column if not exists attempts integer not null default 0 check (attempts >= 0);
+alter table slack_incoming_reports add column if not exists available_at timestamptz not null default now();
+alter table slack_incoming_reports add column if not exists last_error text;
+alter table slack_incoming_reports add column if not exists dead_at timestamptz;
+
+create index if not exists slack_incoming_reports_ready_idx
+  on slack_incoming_reports (available_at, created_at)
+  where processed_at is null and dead_at is null;
+
+alter table slack_report_reactions add column if not exists attempts integer not null default 0 check (attempts >= 0);
+alter table slack_report_reactions add column if not exists available_at timestamptz not null default now();
+alter table slack_report_reactions add column if not exists last_error text;
+alter table slack_report_reactions add column if not exists dead_at timestamptz;
+
+create index if not exists slack_report_reactions_ready_idx
+  on slack_report_reactions (available_at)
+  where processed_at is null and dead_at is null;


### PR DESCRIPTION
## Summary

Slack日報取り込み・Slackリアクション同期で、処理不能なイベントがpending queueを占有し続けて後続の正常イベントを阻害し得る問題を、現在の`main`系へ載せ直して修正します。

Supersedes #30. 旧PRは古いbaseとmigration番号衝突があるため、そのままmergeしません。

## Changes

- `slack_incoming_reports` / `slack_report_reactions`へretry / dead-letter stateを追加
  - `attempts`
  - `available_at`
  - `last_error`
  - `dead_at`
- pending取得を`dead_at is null AND available_at <= now()`に限定
- Slack上で利用不能/Bot/削除済みuserは`slack_user_unavailable`としてDead Letter化
- 一時失敗は最大5回、5s / 15s / 30s / 60s / 300sでbackoff
- 最大回数到達後は`retry_exhausted`
- reaction対象reportが消えている場合は`report_missing`
- より新しいSlack edit/reaction eventが届いた場合はretry/dead状態をreset
- current mainの`Asia/Tokyo`変換とLike Notification処理を保持

## Safe rollout

Application deployがDB migrationより先に完了してもSlack webhookを壊さないよう、`SLACK_INGESTION_RETRY_MODE`で段階導入します。

- 未設定 / `off`: 既存schemaだけを使い、新しいretry列へアクセスしません。
- `enforce`: migration適用後にretry / dead-letterを有効化します。

導入順:
1. modeを`off`のままcode deploy
2. `supabase/migrations/202609070007_slack_incoming_retry_state.sql`をproduction DBへ適用
3. 新しい4列を確認
4. `SLACK_INGESTION_RETRY_MODE=enforce`へ変更してredeploy
5. retry / dead-letter挙動を確認

詳細: `docs/slack-ingestion-retry-rollout.md`

## Migration

`supabase/migrations/202609070007_slack_incoming_retry_state.sql`

旧#30の`202609070002...`は、current mainですでに`202609070002_like_notifications.sql`が存在するため使用しません。#56のAPI rate limitが`0006`を使用するため、このreplacementでは`0007`を使用します。

## Why replacement PR

#30は古いmainから分岐しておりconflictしていました。単純merge/rebaseで新しいtimezone・like notification変更を失わないよう、current main系から安全に再構築しています。
