### PR TITLE
chore: upgrade CodeQL Action to v4.37.9

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           persist-credentials: false
-      - uses: github/codeql-action/init@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+      - uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: javascript-typescript
-      - uses: github/codeql-action/analyze@6f5948dfacef28e207b48d0905cf90c03365536d # v3.37.9
+      - uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9


### PR DESCRIPTION
## Summary

Upgrade both CodeQL `init` and `analyze` together to the same v4.37.9 full commit SHA.

Supersedes #65 and #67. Those split Dependabot PRs fail because CodeQL requires all `github/codeql-action` steps in one workflow to use the same action version.

## Changes

- `github/codeql-action/init` → v4.37.9 (`cdf488f595d80d6e07e03d4674febd5ab45fa938`)
- `github/codeql-action/analyze` → same v4.37.9 SHA
- retain full-SHA pinning

## Validation

Merge only after CI and CodeQL both pass.