### PR TITLE
security: suppress false-positive OAuth state HMAC alert

### DIFF
--- a/src/server/integrations/notion-oauth-crypto.ts
+++ b/src/server/integrations/notion-oauth-crypto.ts
@@ -184,6 +184,9 @@ interface OAuthStatePayload {
 }
 
 function signStatePayload(payload: string, secret: string): Buffer {
+  // AUTH_SECRET is a server-held HMAC signing key for OAuth state integrity,
+  // not a user password or stored password verifier.
+  // codeql[js/insufficient-password-hash]
   return createHmac("sha256", secret).update(payload).digest();
 }
 


### PR DESCRIPTION
## Summary

Resolve CodeQL alert #1 (`js/insufficient-password-hash`) at the Notion OAuth state signer.

The reported value is not a user password or password verifier. `AUTH_SECRET` is used as a server-held HMAC key to authenticate the OAuth `state` payload with HMAC-SHA-256. Password-hardening KDFs such as bcrypt/scrypt/Argon2 are not appropriate for this message-authentication use case.

This PR adds a **query-specific inline CodeQL suppression only at the HMAC operation**, with an adjacent rationale. It does not disable the rule globally and does not change runtime behavior.

## Validation

- Diff is limited to three comment lines in `notion-oauth-crypto.ts`
- Existing OAuth state tests remain authoritative for signing, tamper detection, member binding, and expiry
- CI and CodeQL must pass before merge
