### PR TITLE
security: pin CodeQL OAuth HMAC suppression to alert line

### DIFF
--- a/src/server/integrations/notion-oauth-crypto.ts
+++ b/src/server/integrations/notion-oauth-crypto.ts
@@ -186,8 +186,7 @@ interface OAuthStatePayload {
 function signStatePayload(payload: string, secret: string): Buffer {
   // AUTH_SECRET is a server-held HMAC signing key for OAuth state integrity,
   // not a user password or stored password verifier.
-  // codeql[js/insufficient-password-hash]
-  return createHmac("sha256", secret).update(payload).digest();
+  return createHmac("sha256", secret).update(payload).digest(); // lgtm[js/insufficient-password-hash]
 }
 
 export function createNotionOAuthState(


### PR DESCRIPTION
## Summary

Resolve the remaining false-positive `js/insufficient-password-hash` finding for the Notion OAuth state signer.

`AUTH_SECRET` is used as a server-held HMAC key for OAuth state integrity, not as a user password or stored password verifier. HMAC-SHA-256 is appropriate for this use case.

The previous `// codeql[...]` suppression was placed on the line before the HMAC expression, but the alert remained open on the default branch. This PR switches to the supported same-line `// lgtm[js/insufficient-password-hash]` form so the suppression is anchored to the exact CodeQL alert location.

## Scope

- no runtime behavior change
- no crypto algorithm change
- no rule-wide CodeQL disable
- only the query-specific source suppression placement changes

## Validation

CI and CodeQL must pass before merge.