### PR TITLE
ops: add automated backup and restore drill

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,111 @@
+name: Backup
+
+on:
+  schedule:
+    # 03:20 JST every day.
+    - cron: "20 18 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  backup:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    env:
+      PRODUCTION_DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+      PRODUCTION_SUPABASE_URL: ${{ secrets.PRODUCTION_SUPABASE_URL }}
+      PRODUCTION_SUPABASE_SECRET_KEY: ${{ secrets.PRODUCTION_SUPABASE_SECRET_KEY }}
+      PRODUCTION_SUPABASE_STORAGE_BUCKET: ${{ vars.PRODUCTION_SUPABASE_STORAGE_BUCKET || 'hanabi-log-private' }}
+      BACKUP_SUPABASE_URL: ${{ secrets.BACKUP_SUPABASE_URL }}
+      BACKUP_SUPABASE_SECRET_KEY: ${{ secrets.BACKUP_SUPABASE_SECRET_KEY }}
+      BACKUP_SUPABASE_STORAGE_BUCKET: ${{ vars.BACKUP_SUPABASE_STORAGE_BUCKET || 'hanabi-log-backups' }}
+      RESTORE_DRILL_SLACK_WEBHOOK_URL: ${{ secrets.RESTORE_DRILL_SLACK_WEBHOOK_URL }}
+
+    steps:
+      - name: Check backup configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          for name in \
+            PRODUCTION_DATABASE_URL \
+            PRODUCTION_SUPABASE_URL \
+            PRODUCTION_SUPABASE_SECRET_KEY \
+            BACKUP_SUPABASE_URL \
+            BACKUP_SUPABASE_SECRET_KEY
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "Required backup configuration is missing: ${name}"
+              exit 1
+            fi
+          done
+
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Dump application database schemas
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/hanabi-backup"
+          docker run --rm \
+            -v "$RUNNER_TEMP/hanabi-backup:/backup" \
+            postgres:17 \
+            pg_dump "$PRODUCTION_DATABASE_URL" \
+              --format=custom \
+              --compress=9 \
+              --no-owner \
+              --no-acl \
+              --schema=public \
+              --schema=supabase_migrations \
+              --file=/backup/database.dump
+
+      - name: Export private Storage
+        run: npm run backup:storage -- "$RUNNER_TEMP/hanabi-backup/storage"
+
+      - name: Package Storage backup
+        shell: bash
+        run: |
+          set -euo pipefail
+          tar -C "$RUNNER_TEMP/hanabi-backup/storage" \
+            -czf "$RUNNER_TEMP/hanabi-backup/storage.tar.gz" objects
+
+      - name: Persist backup outside production project
+        run: >-
+          npm run backup:upload --
+          "$RUNNER_TEMP/hanabi-backup/database.dump"
+          "$RUNNER_TEMP/hanabi-backup/storage.tar.gz"
+          "$RUNNER_TEMP/hanabi-backup/storage/manifest.json"
+
+      - name: Remove temporary backup data
+        if: always()
+        shell: bash
+        run: rm -rf "$RUNNER_TEMP/hanabi-backup"
+
+      - name: Notify backup failure
+        if: failure()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${RESTORE_DRILL_SLACK_WEBHOOK_URL:-}" ]; then
+            echo "Backup failed; no Slack alert webhook is configured."
+            exit 0
+          fi
+          payload="$(jq -nc --arg run "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{text:("Hanabi LOG backup failed. Actions: " + $run)}')"
+          curl --fail --silent --show-error \
+            -H 'Content-Type: application/json' \
+            --data "$payload" \
+            "$RESTORE_DRILL_SLACK_WEBHOOK_URL" >/dev/null

--- a/.github/workflows/restore-drill.yml
+++ b/.github/workflows/restore-drill.yml
@@ -1,0 +1,153 @@
+name: Restore Drill
+
+on:
+  schedule:
+    # First Sunday-like weekly cadence; a successful drill every month is the operational target.
+    - cron: "40 18 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  restore-drill:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: hanabi_restore
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d hanabi_restore"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    env:
+      BACKUP_SUPABASE_URL: ${{ secrets.BACKUP_SUPABASE_URL }}
+      BACKUP_SUPABASE_SECRET_KEY: ${{ secrets.BACKUP_SUPABASE_SECRET_KEY }}
+      BACKUP_SUPABASE_STORAGE_BUCKET: ${{ vars.BACKUP_SUPABASE_STORAGE_BUCKET || 'hanabi-log-backups' }}
+      PRODUCTION_DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
+      RESTORE_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/hanabi_restore
+      RESTORE_DRILL_SLACK_WEBHOOK_URL: ${{ secrets.RESTORE_DRILL_SLACK_WEBHOOK_URL }}
+
+    steps:
+      - name: Check restore-drill configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          for name in BACKUP_SUPABASE_URL BACKUP_SUPABASE_SECRET_KEY PRODUCTION_DATABASE_URL
+          do
+            if [ -z "${!name:-}" ]; then
+              echo "Required restore-drill configuration is missing: ${name}"
+              exit 1
+            fi
+          done
+
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Record restore drill start
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm --network host postgres:17 \
+            psql "$PRODUCTION_DATABASE_URL" -v ON_ERROR_STOP=1 \
+            -v run_id="$GITHUB_RUN_ID" -v source_sha="$GITHUB_SHA" \
+            -c "insert into restore_drill_runs (run_id, status, source_commit_sha, started_at, updated_at) values (:'run_id', 'running', :'source_sha', now(), now()) on conflict (run_id) do update set status='running', source_commit_sha=excluded.source_commit_sha, started_at=now(), completed_at=null, error_code=null, updated_at=now();"
+
+      - name: Download latest isolated backup
+        run: npm run backup:download -- "$RUNNER_TEMP/hanabi-restore"
+
+      - name: Associate drill with backup
+        shell: bash
+        run: |
+          set -euo pipefail
+          backup_id="$(jq -r '.backupId' "$RUNNER_TEMP/hanabi-restore/backup-pointer.json")"
+          docker run --rm --network host postgres:17 \
+            psql "$PRODUCTION_DATABASE_URL" -v ON_ERROR_STOP=1 \
+            -v run_id="$GITHUB_RUN_ID" -v backup_id="$backup_id" \
+            -c "update restore_drill_runs set backup_id=:'backup_id', updated_at=now() where run_id=:'run_id';"
+
+      - name: Restore database into isolated PostgreSQL
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm --network host \
+            -v "$RUNNER_TEMP/hanabi-restore:/restore:ro" \
+            postgres:17 \
+            pg_restore \
+              --exit-on-error \
+              --no-owner \
+              --no-acl \
+              --dbname "$RESTORE_DATABASE_URL" \
+              /restore/database.dump
+
+      - name: Restore Storage into isolated filesystem
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/hanabi-restore/storage"
+          tar -xzf "$RUNNER_TEMP/hanabi-restore/storage.tar.gz" \
+            -C "$RUNNER_TEMP/hanabi-restore/storage"
+
+      - name: Verify schema, relations, attachments, and checksums
+        run: >-
+          npm run restore:verify --
+          "$RUNNER_TEMP/hanabi-restore/storage-manifest.json"
+          "$RUNNER_TEMP/hanabi-restore/storage/objects"
+
+      - name: Record restore drill success
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker run --rm --network host postgres:17 \
+            psql "$PRODUCTION_DATABASE_URL" -v ON_ERROR_STOP=1 \
+            -v run_id="$GITHUB_RUN_ID" \
+            -c "update restore_drill_runs set status='passed', completed_at=now(), error_code=null, updated_at=now() where run_id=:'run_id';"
+
+      - name: Record restore drill failure
+        if: failure()
+        continue-on-error: true
+        shell: bash
+        run: |
+          docker run --rm --network host postgres:17 \
+            psql "$PRODUCTION_DATABASE_URL" -v ON_ERROR_STOP=1 \
+            -v run_id="$GITHUB_RUN_ID" \
+            -c "update restore_drill_runs set status='failed', completed_at=now(), error_code='WORKFLOW_FAILED', updated_at=now() where run_id=:'run_id';"
+
+      - name: Remove restored production data from runner
+        if: always()
+        shell: bash
+        run: rm -rf "$RUNNER_TEMP/hanabi-restore"
+
+      - name: Notify restore-drill failure
+        if: failure()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${RESTORE_DRILL_SLACK_WEBHOOK_URL:-}" ]; then
+            echo "Restore drill failed; no Slack alert webhook is configured."
+            exit 0
+          fi
+          payload="$(jq -nc --arg run "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            '{text:("Hanabi LOG restore drill failed. Actions: " + $run)}')"
+          curl --fail --silent --show-error \
+            -H 'Content-Type: application/json' \
+            --data "$payload" \
+            "$RESTORE_DRILL_SLACK_WEBHOOK_URL" >/dev/null

--- a/docs/backup-and-restore.md
+++ b/docs/backup-and-restore.md
@@ -1,0 +1,115 @@
+# Backup and automated restore drills
+
+Hanabi LOGは「backup jobが成功した」ことではなく、**DBとPrivate Storageを実際に隔離環境へ復元して整合性検証できたこと**を復旧可能性の基準にします。
+
+## Objectives
+
+初期SLOはDisaster Recovery Runbookと同じです。
+
+- RPO: 24時間
+- RTO: 4時間
+- DB backup: 毎日
+- Private Storage backup: 毎日、DBとは別ファイル/manifest
+- Automated restore drill: 毎週実行し、最低でも月1回の成功を維持
+
+RPO/RTOは実測restore時間とデータ量に応じて見直します。
+
+## Backup boundary
+
+正本は次の2系統です。
+
+1. PostgreSQL application schemas
+   - `public`
+   - `supabase_migrations`
+2. Supabase Private Storage bucket
+   - object bytes
+   - object path
+   - byte size
+   - SHA-256 manifest
+
+Slack / Notionは配信先でありbackupの正本にはしません。
+
+## Isolation
+
+Backup destinationには**本番Supabase projectとは別のSupabase project**を使用します。バックアップ先bucketはprivateのままにし、公開URLを作りません。
+
+GitHub Actions artifactへ本番dump、Private Storage bytes、manifestを保存しません。Workflow logにも本文、object path、token、dump内容を出しません。
+
+## Required repository secrets
+
+Repository AdminがGitHub Actions secretsへ設定します。
+
+- `PRODUCTION_DATABASE_URL`
+- `PRODUCTION_SUPABASE_URL`
+- `PRODUCTION_SUPABASE_SECRET_KEY`
+- `BACKUP_SUPABASE_URL`
+- `BACKUP_SUPABASE_SECRET_KEY`
+- `RESTORE_DRILL_SLACK_WEBHOOK_URL`（推奨。失敗通知用）
+
+Repository variablesは任意です。
+
+- `PRODUCTION_SUPABASE_STORAGE_BUCKET` default `hanabi-log-private`
+- `BACKUP_SUPABASE_STORAGE_BUCKET` default `hanabi-log-backups`
+
+秘密値をIssue、PR本文、docsへ貼り付けないでください。
+
+## Daily backup workflow
+
+`.github/workflows/backup.yml`は毎日03:20 JSTに実行します。
+
+1. PostgreSQL 17 clientで`public` + `supabase_migrations`をcustom-format dump
+2. Private Storageをserver credentialで列挙
+3. 各objectをdownloadし、sizeとSHA-256をmanifestへ保存
+4. Storage bytesをarchive化
+5. DB dump / Storage archive / manifestを別Supabase projectのprivate bucketへupload
+6. `latest.json` pointerを更新
+7. runner上の一時データを削除
+
+DBとStorageは別backup payloadなので、片方だけの破損もrestore drillで検出できます。
+
+## Automated restore drill
+
+`.github/workflows/restore-drill.yml`は毎週実行します。
+
+1. Backup projectの`latest.json`を読む
+2. DB dump / Storage archive / manifestを取得
+3. GitHub Actions上のfresh PostgreSQL 17 serviceへDBをrestore
+4. Storage archiveをrunnerの隔離directoryへ展開
+5. `scripts/verify-restore.ts`で以下を検証
+   - required tablesの存在
+   - 最新migration version
+   - report/member等の参照整合性
+   - DB attachmentがStorage manifestに存在
+   - attachment byte size一致
+   - 全Storage objectのSHA-256一致
+   - 主要table件数をaggregateだけで確認
+6. production DBの`restore_drill_runs`へpassed/failedだけを記録
+7. 失敗時はSlack webhookへActions run URLだけを通知
+8. runner上のrestoreデータを削除
+
+復元した本文やobject名を`restore_drill_runs`へ保存しません。
+
+## Migration order
+
+Application release前にrepositoryのmigrationをproductionへ適用します。Daily backupは`supabase_migrations.schema_migrations`もdumpし、restore drillはrepository内の最新migration prefixが復元DBに存在することを確認します。
+
+つまりschema変更後にbackupが更新されなければrestore testが失敗し、古いbackupを「復旧可能」と誤認しません。
+
+## First-time setup / acceptance
+
+コードをmergeしただけではrestore保証は完了しません。Repository Adminは次を実施してください。
+
+1. 本番とは別のbackup Supabase projectを作成
+2. 上記secretsを登録
+3. DB migrationを適用
+4. `Backup` workflowを手動実行して成功させる
+5. `Restore Drill` workflowを手動実行して成功させる
+6. `restore_drill_runs`に`passed`が記録されることを確認
+7. Slack failure notificationをテストする
+8. その後scheduled workflowを継続監視する
+
+初回restore drillが成功するまではIssue #35を完了扱いにしません。
+
+## Manual recovery
+
+実障害時の復旧判断、credential rotation、DNS、外部service切り分け、復旧後checklistは`docs/disaster-recovery.md`を参照してください。Automated drillはRunbookを置き換えるものではありません。

--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
     "test:e2e": "playwright test",
     "check": "npm run lint && npm run typecheck && npm run test && npm run build",
     "notion:check": "tsx scripts/notion-check.ts",
-    "notion:migrate": "tsx scripts/notion-migrate.ts"
+    "notion:migrate": "tsx scripts/notion-migrate.ts",
+    "backup:storage": "tsx scripts/backup-storage.ts",
+    "backup:upload": "tsx scripts/upload-backup.ts",
+    "backup:download": "tsx scripts/download-backup.ts",
+    "restore:verify": "tsx scripts/verify-restore.ts"
   },
   "dependencies": {
     "@notionhq/client": "5.25.2",

--- a/scripts/backup-storage.ts
+++ b/scripts/backup-storage.ts
@@ -1,0 +1,98 @@
+import { createHash } from "node:crypto";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { createClient } from "@supabase/supabase-js";
+
+interface ManifestEntry {
+  path: string;
+  sizeBytes: number;
+  sha256: string;
+}
+
+function required(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function safeStoragePath(value: string): string {
+  const normalized = value.replaceAll("\\", "/").replace(/^\/+/, "");
+  if (!normalized || normalized.split("/").some((part) => !part || part === "." || part === "..")) {
+    throw new Error("Unsafe storage object path in backup source");
+  }
+  return normalized;
+}
+
+async function main(): Promise<void> {
+  const outputRoot = path.resolve(process.argv[2] ?? ".restore-drill/storage");
+  const objectRoot = path.join(outputRoot, "objects");
+  await mkdir(objectRoot, { recursive: true });
+
+  const source = createClient(
+    required("PRODUCTION_SUPABASE_URL"),
+    required("PRODUCTION_SUPABASE_SECRET_KEY"),
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+  const bucket = process.env.PRODUCTION_SUPABASE_STORAGE_BUCKET?.trim() || "hanabi-log-private";
+  const manifest: ManifestEntry[] = [];
+
+  async function walk(prefix = ""): Promise<void> {
+    let offset = 0;
+    while (true) {
+      const { data, error } = await source.storage.from(bucket).list(prefix, {
+        limit: 1000,
+        offset,
+        sortBy: { column: "name", order: "asc" },
+      });
+      if (error) throw new Error(`Could not list private storage backup source: ${error.message}`);
+      if (!data?.length) break;
+
+      for (const item of data) {
+        const objectPath = safeStoragePath(prefix ? `${prefix}/${item.name}` : item.name);
+        const size = Number(item.metadata?.size);
+        if (!Number.isFinite(size)) {
+          await walk(objectPath);
+          continue;
+        }
+        const { data: blob, error: downloadError } = await source.storage.from(bucket).download(objectPath);
+        if (downloadError || !blob) {
+          throw new Error(`Could not download a private storage object for backup: ${downloadError?.message ?? "unknown"}`);
+        }
+        const bytes = Buffer.from(await blob.arrayBuffer());
+        if (bytes.byteLength !== size) throw new Error("Storage object size changed during backup");
+        const destination = path.join(objectRoot, ...objectPath.split("/"));
+        await mkdir(path.dirname(destination), { recursive: true });
+        await writeFile(destination, bytes, { flag: "wx" });
+        manifest.push({
+          path: objectPath,
+          sizeBytes: bytes.byteLength,
+          sha256: createHash("sha256").update(bytes).digest("hex"),
+        });
+      }
+
+      if (data.length < 1000) break;
+      offset += data.length;
+    }
+  }
+
+  await walk();
+  manifest.sort((left, right) => left.path.localeCompare(right.path));
+  await writeFile(
+    path.join(outputRoot, "manifest.json"),
+    JSON.stringify(
+      {
+        format: "hanabi-storage-backup-v1",
+        generatedAt: new Date().toISOString(),
+        bucket,
+        objectCount: manifest.length,
+        objects: manifest,
+      },
+      null,
+      2,
+    ),
+    { flag: "wx" },
+  );
+  console.log(`Storage backup prepared: ${manifest.length} objects`);
+}
+
+await main();

--- a/scripts/download-backup.ts
+++ b/scripts/download-backup.ts
@@ -1,0 +1,53 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { z } from "zod";
+import { createClient } from "@supabase/supabase-js";
+
+const pointerSchema = z.object({
+  format: z.literal("hanabi-backup-pointer-v1"),
+  backupId: z.string().min(1).max(200).regex(/^[A-Za-z0-9._-]+$/),
+  createdAt: z.string(),
+  sourceCommit: z.string().nullable().optional(),
+}).strict();
+
+function required(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function downloadObject(
+  client: ReturnType<typeof createClient>,
+  bucket: string,
+  objectPath: string,
+  destination: string,
+): Promise<void> {
+  const { data, error } = await client.storage.from(bucket).download(objectPath);
+  if (error || !data) throw new Error(`Could not download restore input: ${error?.message ?? "unknown"}`);
+  await writeFile(destination, Buffer.from(await data.arrayBuffer()), { flag: "wx" });
+}
+
+async function main(): Promise<void> {
+  const outputRoot = path.resolve(process.argv[2] ?? ".restore-drill/input");
+  await mkdir(outputRoot, { recursive: true });
+  const client = createClient(
+    required("BACKUP_SUPABASE_URL"),
+    required("BACKUP_SUPABASE_SECRET_KEY"),
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+  const bucket = process.env.BACKUP_SUPABASE_STORAGE_BUCKET?.trim() || "hanabi-log-backups";
+
+  const { data: pointerBlob, error: pointerError } = await client.storage.from(bucket).download("latest.json");
+  if (pointerError || !pointerBlob) {
+    throw new Error(`Could not read latest backup pointer: ${pointerError?.message ?? "unknown"}`);
+  }
+  const pointer = pointerSchema.parse(JSON.parse(await pointerBlob.text()));
+
+  await downloadObject(client, bucket, `${pointer.backupId}/database.dump`, path.join(outputRoot, "database.dump"));
+  await downloadObject(client, bucket, `${pointer.backupId}/storage.tar.gz`, path.join(outputRoot, "storage.tar.gz"));
+  await downloadObject(client, bucket, `${pointer.backupId}/storage-manifest.json`, path.join(outputRoot, "storage-manifest.json"));
+  await writeFile(path.join(outputRoot, "backup-pointer.json"), JSON.stringify(pointer, null, 2), { flag: "wx" });
+  console.log(`Restore input downloaded: ${pointer.backupId}`);
+}
+
+await main();

--- a/scripts/download-backup.ts
+++ b/scripts/download-backup.ts
@@ -16,17 +16,6 @@ function required(name: string): string {
   return value;
 }
 
-async function downloadObject(
-  client: ReturnType<typeof createClient>,
-  bucket: string,
-  objectPath: string,
-  destination: string,
-): Promise<void> {
-  const { data, error } = await client.storage.from(bucket).download(objectPath);
-  if (error || !data) throw new Error(`Could not download restore input: ${error?.message ?? "unknown"}`);
-  await writeFile(destination, Buffer.from(await data.arrayBuffer()), { flag: "wx" });
-}
-
 async function main(): Promise<void> {
   const outputRoot = path.resolve(process.argv[2] ?? ".restore-drill/input");
   await mkdir(outputRoot, { recursive: true });
@@ -37,15 +26,21 @@ async function main(): Promise<void> {
   );
   const bucket = process.env.BACKUP_SUPABASE_STORAGE_BUCKET?.trim() || "hanabi-log-backups";
 
+  async function downloadObject(objectPath: string, destination: string): Promise<void> {
+    const { data, error } = await client.storage.from(bucket).download(objectPath);
+    if (error || !data) throw new Error(`Could not download restore input: ${error?.message ?? "unknown"}`);
+    await writeFile(destination, Buffer.from(await data.arrayBuffer()), { flag: "wx" });
+  }
+
   const { data: pointerBlob, error: pointerError } = await client.storage.from(bucket).download("latest.json");
   if (pointerError || !pointerBlob) {
     throw new Error(`Could not read latest backup pointer: ${pointerError?.message ?? "unknown"}`);
   }
   const pointer = pointerSchema.parse(JSON.parse(await pointerBlob.text()));
 
-  await downloadObject(client, bucket, `${pointer.backupId}/database.dump`, path.join(outputRoot, "database.dump"));
-  await downloadObject(client, bucket, `${pointer.backupId}/storage.tar.gz`, path.join(outputRoot, "storage.tar.gz"));
-  await downloadObject(client, bucket, `${pointer.backupId}/storage-manifest.json`, path.join(outputRoot, "storage-manifest.json"));
+  await downloadObject(`${pointer.backupId}/database.dump`, path.join(outputRoot, "database.dump"));
+  await downloadObject(`${pointer.backupId}/storage.tar.gz`, path.join(outputRoot, "storage.tar.gz"));
+  await downloadObject(`${pointer.backupId}/storage-manifest.json`, path.join(outputRoot, "storage-manifest.json"));
   await writeFile(path.join(outputRoot, "backup-pointer.json"), JSON.stringify(pointer, null, 2), { flag: "wx" });
   console.log(`Restore input downloaded: ${pointer.backupId}`);
 }

--- a/scripts/upload-backup.ts
+++ b/scripts/upload-backup.ts
@@ -1,0 +1,66 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { createClient } from "@supabase/supabase-js";
+
+function required(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function main(): Promise<void> {
+  const databaseDump = path.resolve(process.argv[2] ?? ".restore-drill/hanabi-db.dump");
+  const storageArchive = path.resolve(process.argv[3] ?? ".restore-drill/hanabi-storage.tar.gz");
+  const storageManifest = path.resolve(process.argv[4] ?? ".restore-drill/storage/manifest.json");
+  const backup = createClient(
+    required("BACKUP_SUPABASE_URL"),
+    required("BACKUP_SUPABASE_SECRET_KEY"),
+    { auth: { persistSession: false, autoRefreshToken: false } },
+  );
+  const bucket = process.env.BACKUP_SUPABASE_STORAGE_BUCKET?.trim() || "hanabi-log-backups";
+  const timestamp = new Date().toISOString().replaceAll(":", "-").replaceAll(".", "-");
+  const commit = (process.env.GITHUB_SHA || "manual").slice(0, 12);
+  const backupId = `${timestamp}-${commit}`;
+
+  const { data: buckets, error: bucketListError } = await backup.storage.listBuckets();
+  if (bucketListError) throw new Error(`Could not inspect backup bucket: ${bucketListError.message}`);
+  if (!buckets?.some((candidate) => candidate.name === bucket)) {
+    const { error } = await backup.storage.createBucket(bucket, {
+      public: false,
+      fileSizeLimit: 1024 * 1024 * 1024,
+    });
+    if (error) throw new Error(`Could not create private backup bucket: ${error.message}`);
+  }
+
+  const files = [
+    { key: "database.dump", file: databaseDump, contentType: "application/octet-stream" },
+    { key: "storage.tar.gz", file: storageArchive, contentType: "application/gzip" },
+    { key: "storage-manifest.json", file: storageManifest, contentType: "application/json" },
+  ];
+  for (const item of files) {
+    const bytes = await readFile(item.file);
+    const { error } = await backup.storage.from(bucket).upload(
+      `${backupId}/${item.key}`,
+      bytes,
+      { upsert: false, contentType: item.contentType, cacheControl: "0" },
+    );
+    if (error) throw new Error(`Could not persist ${item.key} backup: ${error.message}`);
+  }
+
+  const pointer = Buffer.from(JSON.stringify({
+    format: "hanabi-backup-pointer-v1",
+    backupId,
+    createdAt: new Date().toISOString(),
+    sourceCommit: process.env.GITHUB_SHA || null,
+  }));
+  const { error: pointerError } = await backup.storage.from(bucket).upload(
+    "latest.json",
+    pointer,
+    { upsert: true, contentType: "application/json", cacheControl: "0" },
+  );
+  if (pointerError) throw new Error(`Could not update latest backup pointer: ${pointerError.message}`);
+
+  console.log(`Backup persisted successfully: ${backupId}`);
+}
+
+await main();

--- a/scripts/verify-restore.ts
+++ b/scripts/verify-restore.ts
@@ -1,0 +1,145 @@
+import { createHash } from "node:crypto";
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import postgres from "postgres";
+import { z } from "zod";
+
+const manifestSchema = z.object({
+  format: z.literal("hanabi-storage-backup-v1"),
+  generatedAt: z.string(),
+  bucket: z.string(),
+  objectCount: z.number().int().nonnegative(),
+  objects: z.array(z.object({
+    path: z.string().min(1),
+    sizeBytes: z.number().int().nonnegative(),
+    sha256: z.string().regex(/^[a-f0-9]{64}$/),
+  }).strict()),
+}).strict();
+
+function required(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+async function latestExpectedMigration(): Promise<string> {
+  const directory = path.resolve("supabase/migrations");
+  const names = (await readdir(directory))
+    .filter((name) => /^\d+.*\.sql$/.test(name))
+    .sort();
+  const latest = names.at(-1)?.match(/^(\d+)/)?.[1];
+  if (!latest) throw new Error("Could not determine expected schema migration version");
+  return latest;
+}
+
+async function main(): Promise<void> {
+  const manifestPath = path.resolve(process.argv[2] ?? ".restore-drill/input/storage-manifest.json");
+  const storageRoot = path.resolve(process.argv[3] ?? ".restore-drill/storage/objects");
+  const databaseUrl = required("RESTORE_DATABASE_URL");
+  const sql = postgres(databaseUrl, { max: 2, prepare: false });
+
+  try {
+    const manifest = manifestSchema.parse(JSON.parse(await readFile(manifestPath, "utf8")));
+    if (manifest.objectCount !== manifest.objects.length) {
+      throw new Error("Storage manifest object count does not match its entries");
+    }
+    const manifestByPath = new Map(manifest.objects.map((entry) => [entry.path, entry]));
+
+    for (const entry of manifest.objects) {
+      const normalized = entry.path.replaceAll("\\", "/");
+      if (normalized.split("/").some((part) => !part || part === "." || part === "..")) {
+        throw new Error("Unsafe object path in storage manifest");
+      }
+      const filePath = path.join(storageRoot, ...normalized.split("/"));
+      const fileStat = await stat(filePath);
+      if (!fileStat.isFile() || fileStat.size !== entry.sizeBytes) {
+        throw new Error("Restored storage object size mismatch");
+      }
+      const digest = createHash("sha256").update(await readFile(filePath)).digest("hex");
+      if (digest !== entry.sha256) throw new Error("Restored storage object checksum mismatch");
+    }
+
+    const requiredTables = [
+      "members",
+      "reports",
+      "related_links",
+      "attachments",
+      "integration_bindings",
+      "outbox_jobs",
+      "idempotency_keys",
+    ];
+    const tableRows = await sql<{ table_name: string }[]>`
+      select table_name
+      from information_schema.tables
+      where table_schema = 'public' and table_name in ${sql(requiredTables)}
+    `;
+    const existingTables = new Set(tableRows.map((row) => row.table_name));
+    const missingTables = requiredTables.filter((table) => !existingTables.has(table));
+    if (missingTables.length) throw new Error(`Restored DB is missing required tables: ${missingTables.join(", ")}`);
+
+    const integrity = await sql<{
+      reports_without_member: number;
+      links_without_report: number;
+      attachments_without_report: number;
+      bindings_without_report: number;
+      outbox_without_report: number;
+    }[]>`
+      select
+        (select count(*)::int from reports r left join members m on m.id = r.author_id where m.id is null) as reports_without_member,
+        (select count(*)::int from related_links l left join reports r on r.id = l.report_id where r.id is null) as links_without_report,
+        (select count(*)::int from attachments a left join reports r on r.id = a.report_id where r.id is null) as attachments_without_report,
+        (select count(*)::int from integration_bindings b left join reports r on r.id = b.report_id where r.id is null) as bindings_without_report,
+        (select count(*)::int from outbox_jobs o left join reports r on r.id = o.report_id where r.id is null) as outbox_without_report
+    `;
+    if (Object.values(integrity[0] ?? {}).some((count) => Number(count) !== 0)) {
+      throw new Error("Relational integrity check failed in restored database");
+    }
+
+    const attachmentRows = await sql<{ storage_path: string; size_bytes: number }[]>`
+      select storage_path, size_bytes from attachments order by storage_path
+    `;
+    for (const attachment of attachmentRows) {
+      const entry = manifestByPath.get(attachment.storage_path);
+      if (!entry || entry.sizeBytes !== Number(attachment.size_bytes)) {
+        throw new Error("Database attachment does not match restored Storage backup");
+      }
+    }
+
+    const expectedMigration = await latestExpectedMigration();
+    const migrationRows = await sql<{ version: string }[]>`
+      select version::text as version
+      from supabase_migrations.schema_migrations
+      where version = ${expectedMigration}
+      limit 1
+    `;
+    if (!migrationRows[0]) {
+      throw new Error(`Restored database does not include expected migration ${expectedMigration}`);
+    }
+
+    const counts = await sql<{
+      members: number;
+      reports: number;
+      attachments: number;
+      outbox: number;
+    }[]>`
+      select
+        (select count(*)::int from members) as members,
+        (select count(*)::int from reports) as reports,
+        (select count(*)::int from attachments) as attachments,
+        (select count(*)::int from outbox_jobs) as outbox
+    `;
+    const summary = counts[0];
+    console.log("Restore verification passed", {
+      members: summary?.members ?? 0,
+      reports: summary?.reports ?? 0,
+      attachments: summary?.attachments ?? 0,
+      outbox: summary?.outbox ?? 0,
+      storageObjects: manifest.objectCount,
+      migration: expectedMigration,
+    });
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+await main();

--- a/supabase/migrations/202609070010_restore_drill_runs.sql
+++ b/supabase/migrations/202609070010_restore_drill_runs.sql
@@ -1,0 +1,17 @@
+create table if not exists restore_drill_runs (
+  run_id text primary key,
+  backup_id text,
+  status text not null check (status in ('running', 'passed', 'failed')),
+  source_commit_sha text,
+  started_at timestamptz not null default now(),
+  completed_at timestamptz,
+  error_code text,
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists restore_drill_runs_started_idx
+  on restore_drill_runs (started_at desc);
+
+alter table restore_drill_runs enable row level security;
+
+-- Operational status only. Never store restored row contents, object names, credentials, or tokens here.


### PR DESCRIPTION
## Summary

Rebase the existing `ops/automated-restore-drill` work onto the latest `main` without rolling back current dependencies.

## Includes

- daily PostgreSQL + Private Storage backup workflow
- weekly isolated restore drill workflow
- backup upload/download/storage scripts
- restore verification script
- `restore_drill_runs` migration
- backup/restore operations documentation
- npm scripts for backup/restore operations

## Compatibility

The old branch was based on an older dependency set. This replacement keeps the current `main` versions, including `@supabase/supabase-js 2.115.0`, `next 16.3.4`, `vitest 5.0.0`, and `@types/react-dom 19.2.7`.

## Follow-up

Code merge does not by itself complete Issue #35. Production/backup Supabase setup, required GitHub secrets, and successful live Backup + Restore Drill runs are still operational acceptance steps.